### PR TITLE
Fix ViewModel intrusive access

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/data/route/RouteTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/data/route/RouteTest.kt
@@ -66,15 +66,30 @@ class RouteTest {
     @Test
     fun routeViewInitializesCorrectly(){
         val mapView = MapsViewModel()
-        assertEquals(0, mapView.routes.value!!.size)
+        assertEquals(0, mapView.routesState.value!!.size)
     }
 
     @Test
     fun routeViewAdd(){
         val mapView = MapsViewModel()
         val route = Route(10.0, 10.0, 10.0, 10.0)
+        val route2 = Route(10.0, 10.0, 10.0, 10.0)
+        val route3 = Route(10.0, 10.0, 10.0, 10.0)
         mapView.addRoute(route)
-        assertEquals(1, mapView.routes.value!!.size)
+        mapView.addRoute(route2)
+        mapView.addRoute(route3)
+        assertEquals(3, mapView.routesState.value!!.size)
+    }
+
+    @Test
+    fun routeViewAddAll(){
+        val mapView = MapsViewModel()
+        val route = Route(10.0, 10.0, 10.0, 10.0)
+        val route2 = Route(10.0, 10.0, 10.0, 10.0)
+        val route3 = Route(10.0, 10.0, 10.0, 10.0)
+        val ls = listOf(route, route2, route3)
+        mapView.addAll(ls)
+        assertEquals(3, mapView.routesState.value!!.size)
     }
 
     @get:Rule
@@ -84,7 +99,7 @@ class RouteTest {
         val mapView = MapsViewModel()
         val route = Route(10.0, 10.0, 10.0, 10.0)
         mapView.setRunRoute(route)
-        assertEquals(route, mapView.runRoute.value)
+        assertEquals(route, mapView.runRouteState.value)
     }
 
     @Test
@@ -93,6 +108,6 @@ class RouteTest {
         val route = Route(10.0, 10.0, 10.0, 10.0)
         mapView.addRoute(route)
         mapView.deleteAll()
-        assertEquals(0, mapView.routes.value!!.size)
+        assertEquals(0, mapView.routesState.value!!.size)
     }
 }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/directory/ContactDetailsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/directory/ContactDetailsFragmentTest.kt
@@ -11,7 +11,7 @@ import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
-import com.github.factotum_sdp.factotum.contacts_content.ContactsList
+import com.github.factotum_sdp.factotum.placeholder.ContactsList
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/directory/ContactsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/directory/ContactsFragmentTest.kt
@@ -15,7 +15,7 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
-import com.github.factotum_sdp.factotum.contacts_content.ContactsList
+import com.github.factotum_sdp.factotum.placeholder.ContactsList
 import junit.framework.TestCase.assertTrue
 import org.junit.Before
 import org.junit.Rule

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/LoggedInUser.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/LoggedInUser.kt
@@ -1,4 +1,4 @@
-package com.github.factotum_sdp.factotum.data.model
+package com.github.factotum_sdp.factotum.data
 
 /**
  * Data class that captures user information for logged in users retrieved from LoginRepository

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/LoginDataSource.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/LoginDataSource.kt
@@ -1,7 +1,7 @@
 package com.github.factotum_sdp.factotum.data
 
-import com.github.factotum_sdp.factotum.data.model.LoggedInUser
 import java.io.IOException
+import java.util.*
 
 /**
  * Class that handles authentication w/ login credentials and retrieves user information.
@@ -10,7 +10,7 @@ class LoginDataSource {
 
     fun login(username: String, password: String): Result<LoggedInUser> {
         try {
-            val fakeUser = LoggedInUser(java.util.UUID.randomUUID().toString(), username)
+            val fakeUser = LoggedInUser(UUID.randomUUID().toString(), username)
             return Result.Success(fakeUser)
         } catch (e: Throwable) {
             return Result.Error(IOException("Error logging in", e))

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/LoginRepository.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/LoginRepository.kt
@@ -1,7 +1,5 @@
 package com.github.factotum_sdp.factotum.data
 
-import com.github.factotum_sdp.factotum.data.model.LoggedInUser
-
 /**
  * Class that requests authentication and user information from the remote data source and
  * maintains an in-memory cache of login status and user credentials information.

--- a/app/src/main/java/com/github/factotum_sdp/factotum/placeholder/ContactsList.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/placeholder/ContactsList.kt
@@ -1,4 +1,4 @@
-package com.github.factotum_sdp.factotum.contacts_content
+package com.github.factotum_sdp.factotum.placeholder
 
 import com.github.factotum_sdp.factotum.R
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/directory/ContactDetailsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/directory/ContactDetailsFragment.kt
@@ -10,7 +10,7 @@ import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.navigation.findNavController
 import com.github.factotum_sdp.factotum.R
-import com.github.factotum_sdp.factotum.contacts_content.ContactsList
+import com.github.factotum_sdp.factotum.placeholder.ContactsList
 
 class ContactDetailsFragment : Fragment() {
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/directory/ContactsRecyclerAdapter.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/directory/ContactsRecyclerAdapter.kt
@@ -19,9 +19,9 @@ class ContactsRecyclerAdapter : RecyclerView.Adapter<ContactsRecyclerAdapter.Con
 
     inner class ContactsViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) { //this is the view holder for the recycler view
 
-        var itemRole : TextView //these are the views that we want to display for each contact
-        var itemName : TextView
-        var itemImage : ImageView
+        val itemRole : TextView //these are the views that we want to display for each contact
+        val itemName : TextView
+        val itemImage : ImageView
 
         init {
             itemRole = itemView.findViewById(R.id.contact_role) //connect the views to the layout

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/directory/ContactsRecyclerAdapter.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/directory/ContactsRecyclerAdapter.kt
@@ -9,7 +9,7 @@ import android.widget.TextView
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import com.github.factotum_sdp.factotum.R
-import com.github.factotum_sdp.factotum.contacts_content.ContactsList
+import com.github.factotum_sdp.factotum.placeholder.ContactsList
 
 class ContactsRecyclerAdapter : RecyclerView.Adapter<ContactsRecyclerAdapter.ContactsViewHolder>() {
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsFragment.kt
@@ -51,7 +51,7 @@ class MapsFragment : Fragment() {
             // clears map from previous markers
             googleMap.clear()
             //Shows destinations of selected roads
-            for (route in viewModel.routes.value.orEmpty()){
+            for (route in viewModel.routesState.value!!){
                 route.addDstToMap(googleMap)
             }
             googleMap.moveCamera(CameraUpdateFactory.newLatLng(EPFL_LOC))

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsFragment.kt
@@ -51,7 +51,7 @@ class MapsFragment : Fragment() {
             // clears map from previous markers
             googleMap.clear()
             //Shows destinations of selected roads
-            for (route in viewModel.routesState.value!!){
+            for (route in viewModel.routesState.value.orEmpty()){
                 route.addDstToMap(googleMap)
             }
             googleMap.moveCamera(CameraUpdateFactory.newLatLng(EPFL_LOC))

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsFragment.kt
@@ -57,12 +57,6 @@ class MapsFragment : Fragment() {
             // clears map from previous markers
             googleMap.clear()
 
-            //Shows destinations of selected roads
-            for (route in viewModel.routesState.value.orEmpty()){
-                route.addDstToMap(googleMap)
-            }
-            googleMap.moveCamera(CameraUpdateFactory.newLatLng(EPFL_LOC))
-
             // places markers on the map and centers the camera
             placeMarkers(viewModel.routesState, googleMap)
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsViewModel.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.factotum_sdp.factotum.ui.maps
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.github.factotum_sdp.factotum.data.Route
@@ -10,8 +11,10 @@ import com.github.factotum_sdp.factotum.data.Route
  */
 class MapsViewModel : ViewModel() {
 
-    val routes: MutableLiveData<MutableList<Route>> = MutableLiveData(mutableListOf())
-    val runRoute : MutableLiveData<Route> = MutableLiveData()
+    private val _routes: MutableLiveData<List<Route>> = MutableLiveData(listOf())
+    private val _runRoute : MutableLiveData<Route> = MutableLiveData()
+    val routesState: LiveData<List<Route>> = _routes
+    val runRouteState: LiveData<Route> = _runRoute
 
     /**
      * Adds a route to be shown on the map
@@ -19,7 +22,22 @@ class MapsViewModel : ViewModel() {
      * @param route : route to be shown
      */
     fun addRoute(route: Route){
-        routes.value?.add(route)
+        _routes.value?.let{
+            val res = it.plus(route)
+            _routes.postValue(res)
+        }
+    }
+
+    /**
+     * Add a list of route to be shown on the map
+     *
+     * @param routes : routes to be shown
+     */
+    fun addAll(routes: List<Route>) {
+        _routes.value?.let {
+            val res = it.plus(routes)
+            _routes.postValue(res)
+        }
     }
 
     /**
@@ -27,7 +45,7 @@ class MapsViewModel : ViewModel() {
      *
      */
     fun deleteAll(){
-        routes.postValue(mutableListOf())
+        _routes.postValue(listOf())
     }
 
     /**
@@ -36,6 +54,6 @@ class MapsViewModel : ViewModel() {
      * @param route : route to be run
      */
     fun setRunRoute(route: Route){
-        runRoute.postValue(route)
+        _runRoute.postValue(route)
     }
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/RouteFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/RouteFragment.kt
@@ -82,13 +82,11 @@ class RouteFragment : Fragment() {
             findNavController().navigate(R.id.action_FirstFragment_to_SecondFragment)
         }
         binding.buttonAll.setOnClickListener{
-            for(route in DUMMY_ROUTE){
-                viewModel.addRoute(route)
-            }
+            viewModel.addAll(DUMMY_ROUTE)
             findNavController().navigate(R.id.action_FirstFragment_to_SecondFragment)
         }
         binding.buttonRun.setOnClickListener{
-            val route = viewModel.runRoute.value!!
+            val route = viewModel.runRouteState.value!!
             val googleMapsUrl = StringBuilder()
                 .append("http://maps.google.com/maps?")
                 .append("saddr=${route.src.latitude},${route.src.longitude} &")

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -33,7 +33,7 @@ class RoadBookFragment : Fragment() {
 
         // Observe the roadbook ViewModel, to detect data changes
         // and update the displayed RecyclerView accordingly
-        rbViewModel.recordsList.observe(this.viewLifecycleOwner) {
+        rbViewModel.recordsListState.observe(this.viewLifecycleOwner) {
             adapter.submitList(it)
         }
         // Set events that triggers change in the roadbook ViewModel

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewModel.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewModel.kt
@@ -1,5 +1,6 @@
 package com.github.factotum_sdp.factotum.ui.roadbook
 
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
@@ -14,8 +15,10 @@ import java.util.Calendar
  * holds an observable list of DestinationRecord which can evolve dynamically
  */
 class RoadBookViewModel(_dbRef: DatabaseReference) : ViewModel() {
-    val recordsList: MutableLiveData<List<DestinationRecord>> =
+    private val _recordsList: MutableLiveData<List<DestinationRecord>> =
         MutableLiveData(DestinationRecords.RECORDS)
+
+    val recordsListState: LiveData<List<DestinationRecord>> = _recordsList
 
     private var dbRef: DatabaseReference
     init {
@@ -28,20 +31,20 @@ class RoadBookViewModel(_dbRef: DatabaseReference) : ViewModel() {
 
     fun addRecord(destinationRecord: DestinationRecord) {
         val newList = arrayListOf<DestinationRecord>()
-        newList.addAll(recordsList.value as Collection<DestinationRecord>)
+        newList.addAll(_recordsList.value as Collection<DestinationRecord>)
         newList.add(destinationRecord)
-        recordsList.postValue(newList)
+        _recordsList.postValue(newList)
     }
 
     fun deleteLastRecord() {
         val newList = arrayListOf<DestinationRecord>()
-        newList.addAll(recordsList.value as Collection<DestinationRecord>)
+        newList.addAll(_recordsList.value as Collection<DestinationRecord>)
         if (newList.isNotEmpty()) newList.removeLast()
-        recordsList.postValue(newList)
+        _recordsList.postValue(newList)
     }
 
     fun backUp() {
-        dbRef.setValue(recordsList.value)
+        dbRef.setValue(_recordsList.value)
     }
 
     // Factory needed to assign a value at construction time to the class attribute

--- a/app/src/test/java/com/github/factotum_sdp/factotum/LoggedInUserTest.kt
+++ b/app/src/test/java/com/github/factotum_sdp/factotum/LoggedInUserTest.kt
@@ -1,6 +1,6 @@
 package com.github.factotum_sdp.factotum
 
-import com.github.factotum_sdp.factotum.data.model.LoggedInUser
+import com.github.factotum_sdp.factotum.data.LoggedInUser
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 

--- a/app/src/test/java/com/github/factotum_sdp/factotum/LoginDataSourceTest.kt
+++ b/app/src/test/java/com/github/factotum_sdp/factotum/LoginDataSourceTest.kt
@@ -2,10 +2,9 @@ package com.github.factotum_sdp.factotum
 
 import com.github.factotum_sdp.factotum.data.LoginDataSource
 import com.github.factotum_sdp.factotum.data.Result
-import com.github.factotum_sdp.factotum.data.model.LoggedInUser
+import com.github.factotum_sdp.factotum.data.LoggedInUser
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
-import org.junit.Before
 import org.junit.jupiter.api.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock

--- a/app/src/test/java/com/github/factotum_sdp/factotum/LoginRepositoryTest.kt
+++ b/app/src/test/java/com/github/factotum_sdp/factotum/LoginRepositoryTest.kt
@@ -2,7 +2,7 @@ package com.github.factotum_sdp.factotum
 
 import com.github.factotum_sdp.factotum.data.LoginDataSource
 import com.github.factotum_sdp.factotum.data.LoginRepository
-import com.github.factotum_sdp.factotum.data.model.LoggedInUser
+import com.github.factotum_sdp.factotum.data.LoggedInUser
 import com.github.factotum_sdp.factotum.data.Result
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*


### PR DESCRIPTION
Just a quick fix to be more safe in the future about how the ViewModel attributes are set.

In a ViewModel, it is a recommended practice to not expose view model data as public variables. Otherwise the app data can be modified in unexpected ways by the external classes and create edge cases your app didn't expect to handle. Instead, make these mutable properties private, implement a backing property, and expose a public immutable version of each property, if needed. The convention is to prefix the name of the private mutable properties with an underscore (_).

see : https://developer.android.com/codelabs/basic-android-kotlin-training-shared-viewmodel#3