### PR TITLE
Feature/sharing outside proofphoto

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/display/DisplayFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/display/DisplayFragmentTest.kt
@@ -1,6 +1,7 @@
 package com.github.factotum_sdp.factotum.ui.display
 
 import android.content.Context
+import android.content.Intent
 import androidx.fragment.app.testing.FragmentScenario
 import androidx.fragment.app.testing.launchFragmentInContainer
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -8,6 +9,8 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -38,11 +41,13 @@ class DisplayFragmentTest {
         scenario = launchFragmentInContainer(themeResId = R.style.Theme_Factotum)
         Firebase.storage.useEmulator("10.0.2.2", 9199)
         context = InstrumentationRegistry.getInstrumentation().context
+        Intents.init()
     }
 
     @After
     fun tearDown() {
-       emptyStorageEmulator(Firebase.storage.reference)
+        emptyStorageEmulator(Firebase.storage.reference)
+        Intents.release()
     }
 
     @Test
@@ -92,5 +97,24 @@ class DisplayFragmentTest {
             val recyclerView = fragment.requireView().findViewById<RecyclerView>(R.id.recyclerView)
             assert(recyclerView.adapter?.itemCount == 1)
         }
+    }
+
+    @Test
+    fun displayFragment_sharingPhotoWorks() {
+        runBlocking {
+            val imagePath = "test_image1.jpg"
+            uploadImageToStorageEmulator(context, imagePath, "test_image1.jpg")
+        }
+
+        Thread.sleep(WAIT_TIME_INIT)
+
+        onView(withId(R.id.refreshButton)).perform(click())
+
+        Thread.sleep(WAIT_TIME_REFRESH)
+
+        onView(withId(R.id.shareButton)).perform(click())
+
+        //Check if the intent of sharing has been called
+        Intents.intended(hasAction(Intent.ACTION_CHOOSER))
     }
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/DisplayFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/DisplayFragment.kt
@@ -1,15 +1,15 @@
 package com.github.factotum_sdp.factotum.ui.display
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
-import com.github.factotum_sdp.factotum.databinding.DisplayItemBinding
+import com.github.factotum_sdp.factotum.R
 import com.github.factotum_sdp.factotum.databinding.FragmentDisplayBinding
 import com.github.factotum_sdp.factotum.ui.display.utils.PhotoAdapter
 import com.google.firebase.storage.StorageReference
@@ -30,7 +30,9 @@ class DisplayFragment : Fragment() {
         _binding = FragmentDisplayBinding.inflate(inflater, container, false)
 
         // Set up the recycler view with a photo adapter
-        val photoAdapter = PhotoAdapter()
+        val photoAdapter = PhotoAdapter() { storageReference ->
+            shareImage(storageReference, "1234567890")
+        }
         binding.recyclerView.apply {
             layoutManager = LinearLayoutManager(context)
             adapter = photoAdapter
@@ -54,4 +56,39 @@ class DisplayFragment : Fragment() {
         super.onDestroyView()
         _binding = null
     }
+
+    private fun shareImage(storageReference: StorageReference, phoneNumber: String) {
+        storageReference.downloadUrl.addOnSuccessListener { uri ->
+            val shareText = "Here is your delivery: $uri"
+
+            // General sharing intent
+            val generalShareIntent = Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_TEXT, shareText)
+            }
+
+            // Intent for SMS sharing
+            val smsIntent = Intent(Intent.ACTION_SENDTO).apply {
+                data = Uri.parse("smsto:$phoneNumber")
+                putExtra("sms_body", shareText)
+            }
+
+            // Intent for WhatsApp sharing
+            val whatsappIntent = Intent(Intent.ACTION_VIEW).apply {
+                data = Uri.parse("https://api.whatsapp.com/send?phone=$phoneNumber&text=$shareText")
+                setPackage("com.whatsapp")
+            }
+
+            // Create a chooser intent with the option to share via general sharing options and WhatsApp
+            val chooserIntent = Intent.createChooser(generalShareIntent, getString(R.string.share)).apply {
+                putExtra(Intent.EXTRA_INITIAL_INTENTS, arrayOf(whatsappIntent, smsIntent))
+            }
+
+
+            startActivity(chooserIntent)
+        }.addOnFailureListener {
+            // Handle failure here
+        }
+    }
+
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/DisplayFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/DisplayFragment.kt
@@ -14,6 +14,8 @@ import com.github.factotum_sdp.factotum.databinding.FragmentDisplayBinding
 import com.github.factotum_sdp.factotum.ui.display.utils.PhotoAdapter
 import com.google.firebase.storage.StorageReference
 
+const val PHONE_NUMBER = "1234567890"
+
 // Fragment responsible for displaying a list of images from Firebase Storage
 class DisplayFragment : Fragment() {
 
@@ -31,7 +33,7 @@ class DisplayFragment : Fragment() {
 
         // Set up the recycler view with a photo adapter
         val photoAdapter = PhotoAdapter() { storageReference ->
-            shareImage(storageReference, "1234567890")
+            shareImage(storageReference, PHONE_NUMBER)
         }
         binding.recyclerView.apply {
             layoutManager = LinearLayoutManager(context)
@@ -84,10 +86,7 @@ class DisplayFragment : Fragment() {
                 putExtra(Intent.EXTRA_INITIAL_INTENTS, arrayOf(whatsappIntent, smsIntent))
             }
 
-
             startActivity(chooserIntent)
-        }.addOnFailureListener {
-            // Handle failure here
         }
     }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/utils/PhotoAdapter.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/utils/PhotoAdapter.kt
@@ -7,11 +7,11 @@ import com.github.factotum_sdp.factotum.databinding.DisplayItemBinding
 import com.google.firebase.storage.StorageReference
 
 // Adapter for displaying photos in the recycler view
-class PhotoAdapter : ListAdapter<StorageReference, PhotoViewHolder>(PhotoDiffCallback()) {
+class PhotoAdapter(private val onShareClick: (StorageReference) -> Unit = {}) : ListAdapter<StorageReference, PhotoViewHolder>(PhotoDiffCallback()) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PhotoViewHolder {
         val binding = DisplayItemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return PhotoViewHolder(binding)
+        return PhotoViewHolder(binding, onShareClick)
     }
 
     override fun onBindViewHolder(holder: PhotoViewHolder, position: Int) {

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/utils/PhotoDiffCallback.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/utils/PhotoDiffCallback.kt
@@ -5,6 +5,7 @@ import com.google.firebase.storage.StorageReference
 
 // Callback to calculate the difference between two photo items
 class PhotoDiffCallback : DiffUtil.ItemCallback<StorageReference>() {
+
     override fun areItemsTheSame(oldItem: StorageReference, newItem: StorageReference): Boolean {
         return oldItem.path == newItem.path
     }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/utils/PhotoViewHolder.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/utils/PhotoViewHolder.kt
@@ -1,5 +1,6 @@
 package com.github.factotum_sdp.factotum.ui.display.utils
 
+import android.widget.Button
 import androidx.recyclerview.widget.RecyclerView
 import com.github.factotum_sdp.factotum.databinding.DisplayItemBinding
 import com.github.factotum_sdp.factotum.ui.display.GlideApp
@@ -7,11 +8,18 @@ import com.google.firebase.storage.StorageReference
 
 
 // ViewHolder for displaying an individual photo item
-class PhotoViewHolder(private val binding: DisplayItemBinding) : RecyclerView.ViewHolder(binding.root) {
+class PhotoViewHolder(private val binding: DisplayItemBinding, private val onShareClick: (StorageReference) -> Unit) : RecyclerView.ViewHolder(binding.root) {
+
+    private val shareButton: Button = binding.shareButton
+
     fun bind(storageReference: StorageReference) {
         // Load the image using Glide and display it in the ImageView
         GlideApp.with(binding.displayItemView.context)
             .load(storageReference)
             .into(binding.displayItemView)
+
+        shareButton.setOnClickListener {
+            onShareClick(storageReference)
+        }
     }
 }

--- a/app/src/main/res/layout/display_item.xml
+++ b/app/src/main/res/layout/display_item.xml
@@ -14,4 +14,14 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <Button
+        android:id="@+id/shareButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/share"
+        android:layout_margin="8dp"
+        android:background="@color/material_dynamic_neutral10"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/display_item.xml
+++ b/app/src/main/res/layout/display_item.xml
@@ -20,7 +20,7 @@
         android:layout_height="wrap_content"
         android:text="@string/share"
         android:layout_margin="8dp"
-        android:background="@color/material_dynamic_neutral10"
+        android:background="@color/design_default_color_background"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,5 @@
     <string name="editDialogUpdateB">update</string>
     <string name="menu_view_proof_picture">View Proof Pictures</string>
     <string name="refresh">Refresh</string>
+    <string name="share">Share</string>
 </resources>


### PR DESCRIPTION
Extending the idea of using the sharing feature to send the link to the image showing the proof photo of a delivery. The button for sharing is linked to an image such that it has access to the information of that image but resulting in an horrible UI in our case. Of course it will be changed when reworking on the interface and role in later sprint.
It is difficult to test for Whatsapp since installing on the CI and setup an account is difficult, same for SMS, only the firing of the intent to share is easily testable I think? 
I also tried implementing for telegram but apparently you need the pseudo and not the phone number so I don't know if it's a good option to put it or not? Even if you still have of course the possibility to share to any other app, but it will not open and put automatically the text.

I put it as a draft for the moment is some want to test it.