### PR TITLE
Feature/trigger destrecord details

### DIFF
--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/directory/ContactsRecyclerAdapter.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/directory/ContactsRecyclerAdapter.kt
@@ -30,12 +30,11 @@ class ContactsRecyclerAdapter : RecyclerView.Adapter<ContactsRecyclerAdapter.Con
 
             itemView.setOnClickListener {   //when a contact is clicked, go to the contact details fragment
                 itemView.findNavController().navigate(R.id.action_directoryFragment_to_contactDetailsFragment2, Bundle().apply {
-                    putInt("id", bindingAdapterPosition) //pass the id of the contact to the contact details fragment so that it can display the correct contact
+                    putInt("id", bindingAdapterPosition) // pass the id of the contact to the contact details fragment so that it can display the correct contact
                 })
             }
         }
     }
-
 
     override fun onCreateViewHolder(viewGroup: ViewGroup, i: Int): ContactsViewHolder {
         val v = LayoutInflater.from(viewGroup.context)

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordAlertDialogBuilder.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordAlertDialogBuilder.kt
@@ -4,6 +4,7 @@ import android.app.AlertDialog
 import android.app.TimePickerDialog
 import android.content.Context
 import android.content.DialogInterface
+import android.view.ContextThemeWrapper
 import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
@@ -29,7 +30,7 @@ import java.util.*
  *
  * Finally calling the inherited show() method will call create() and make the new custom concrete AlertDialog
  *
- * @param context: Context? The Context wherein this DialogBuilder is instanciated
+ * @param context: Context? The Context wherein this DialogBuilder is instanced
  * @param host: Fragment The Fragment which will hold the AlertDialog
  * @param rbViewModel: RoadBookViewModel The RoadBookViewModel storing the observable data of each DestinationRecord
  * @param rbRecyclerView: RecyclerView The RecyclerView as optimization to notify the screen representation when there is no edit changes,
@@ -40,7 +41,8 @@ import java.util.*
 class DRecordAlertDialogBuilder(context: Context?,
                                 private val host: Fragment,
                                 private val rbViewModel: RoadBookViewModel,
-                                private val rbRecyclerView: RecyclerView) : AlertDialog.Builder(context) {
+                                private val rbRecyclerView: RecyclerView) :
+    AlertDialog.Builder(ContextThemeWrapper(context, android.R.style.Theme_Holo_Dialog)) {
 
     private val clientIDView: AutoCompleteTextView
     private val timestampView: EditText

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordAlertDialogBuilder.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordAlertDialogBuilder.kt
@@ -30,7 +30,7 @@ import java.util.*
  *
  * Finally calling the inherited show() method will call create() and make the new custom concrete AlertDialog
  *
- * @param context: Context? The Context wherein this DialogBuilder is instanced
+ * @param context: Context? The Context wherein this DialogBuilder is instantiated
  * @param host: Fragment The Fragment which will hold the AlertDialog
  * @param rbViewModel: RoadBookViewModel The RoadBookViewModel storing the observable data of each DestinationRecord
  * @param rbRecyclerView: RecyclerView The RecyclerView as optimization to notify the screen representation when there is no edit changes,

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
@@ -1,0 +1,11 @@
+package com.github.factotum_sdp.factotum.ui.roadbook
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import com.github.factotum_sdp.factotum.ui.maps.MapsViewModel
+
+class DRecordDetailsFragment: Fragment() {
+    private val rbViewModel: MapsViewModel by activityViewModels()
+
+
+}

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
@@ -5,7 +5,5 @@ import androidx.fragment.app.activityViewModels
 import com.github.factotum_sdp.factotum.ui.maps.MapsViewModel
 
 class DRecordDetailsFragment: Fragment() {
-    private val rbViewModel: MapsViewModel by activityViewModels()
-
-
+    private val rbViewModel: RoadBookViewModel by activityViewModels()
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
@@ -1,9 +1,19 @@
 package com.github.factotum_sdp.factotum.ui.roadbook
 
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.activityViewModels
-import com.github.factotum_sdp.factotum.ui.maps.MapsViewModel
+import com.github.factotum_sdp.factotum.R
 
 class DRecordDetailsFragment: Fragment() {
-    private val rbViewModel: RoadBookViewModel by activityViewModels()
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_drecord_details, container, false)
+        return view
+    }
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -96,7 +96,6 @@ class RoadBookFragment : Fragment(), MenuProvider {
         val rbSR = menu.findItem(R.id.rbSwipeREdition)
         val rbTC = menu.findItem(R.id.rbTouchClick)
 
-
         // fetch saved States
         fetchRadioButtonState(DRAG_N_DROP_SHARED_KEY, rbDD)
         fetchRadioButtonState(SWIPE_L_SHARED_KEY, rbSL)
@@ -109,6 +108,15 @@ class RoadBookFragment : Fragment(), MenuProvider {
         isSREnabled = rbSR.isChecked
         isTClickEnabled = rbTC.isChecked
 
+        setRBonClickListeners(rbDD, rbSL, rbSR, rbTC)
+
+        // Only at menu initialization
+        val itemTouchHelper = ItemTouchHelper(newItemTHCallBack())
+        itemTouchHelper.attachToRecyclerView(rbRecyclerView)
+    }
+
+    private fun setRBonClickListeners(rbDD: MenuItem, rbSL: MenuItem,
+                                      rbSR: MenuItem, rbTC: MenuItem) {
         rbDD.setOnMenuItemClickListener {
             it.isChecked = !it.isChecked
             isDDropEnabled = !isDDropEnabled
@@ -129,10 +137,6 @@ class RoadBookFragment : Fragment(), MenuProvider {
             isTClickEnabled = !isTClickEnabled
             true
         }
-
-        // Only at menu initialization
-        val itemTouchHelper = ItemTouchHelper(newItemTHCallBack())
-        itemTouchHelper.attachToRecyclerView(rbRecyclerView)
     }
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
         // Needed to have the onSupportNavigateUp() called

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -25,16 +25,19 @@ class RoadBookFragment : Fragment(), MenuProvider {
     private lateinit var rbRecyclerView: RecyclerView
     private lateinit var fragMenu: Menu
 
-    private var sl = true
-    private var sr = true
-    private var dd = true
+    // Checked OptionMenu States with default values
+    // overridden by the device saved SharedPreference
+    private var isSLEnabled = true
+    private var isSREnabled = true
+    private var isDDropEnabled = true
+    private var isTClickEnabled = true
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
 
         val view = inflater.inflate(R.layout.fragment_roadbook, container, false)
-        val adapter = RoadBookViewAdapter(null)
+        val adapter = RoadBookViewAdapter(setOnDRecordClickListener())
         val dbRef = (activity as MainActivity).getDatabaseRef().child(ROADBOOK_DB_PATH)
         val rbFact = RoadBookViewModel.RoadBookViewModelFactory(dbRef)
         rbViewModel = ViewModelProvider(this, rbFact)[RoadBookViewModel::class.java]
@@ -62,9 +65,11 @@ class RoadBookFragment : Fragment(), MenuProvider {
 
     private fun setOnDRecordClickListener(): View.OnClickListener {
         return View.OnClickListener { v ->
-            v
-                ?.findNavController()
-                ?.navigate(R.id.action_roadBookFragment_to_DRecordDetailsFragment)
+            if(isTClickEnabled) {
+                v
+                    ?.findNavController()
+                    ?.navigate(R.id.action_roadBookFragment_to_DRecordDetailsFragment)
+            }
         }
     }
 
@@ -89,31 +94,39 @@ class RoadBookFragment : Fragment(), MenuProvider {
         val rbDD = menu.findItem(R.id.rbDragDrop)
         val rbSL = menu.findItem(R.id.rbSwipeLDeletion)
         val rbSR = menu.findItem(R.id.rbSwipeREdition)
+        val rbTC = menu.findItem(R.id.rbTouchClick)
 
 
         // fetch saved States
         fetchRadioButtonState(DRAG_N_DROP_SHARED_KEY, rbDD)
         fetchRadioButtonState(SWIPE_L_SHARED_KEY, rbSL)
         fetchRadioButtonState(SWIPE_R_SHARED_KEY, rbSR)
+        fetchRadioButtonState(TOUCH_CLICK_SHARED_KEY, rbTC)
 
         // init globals to saved preference state
-        dd = rbDD.isChecked
-        sl = rbSL.isChecked
-        sr = rbSR.isChecked
+        isDDropEnabled = rbDD.isChecked
+        isSLEnabled = rbSL.isChecked
+        isSREnabled = rbSR.isChecked
+        isTClickEnabled = rbTC.isChecked
 
         rbDD.setOnMenuItemClickListener {
             it.isChecked = !it.isChecked
-            dd = !dd
+            isDDropEnabled = !isDDropEnabled
             true
         }
         rbSL.setOnMenuItemClickListener {
             it.isChecked = !it.isChecked
-            sl = !sl
+            isSLEnabled = !isSLEnabled
             true
         }
         rbSR.setOnMenuItemClickListener {
             it.isChecked = !it.isChecked
-            sr = !sr
+            isSREnabled = !isSREnabled
+            true
+        }
+        rbTC.setOnMenuItemClickListener {
+            it.isChecked = !it.isChecked
+            isTClickEnabled = !isTClickEnabled
             true
         }
 
@@ -150,7 +163,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
                 recyclerView: RecyclerView,
                 viewHolder: RecyclerView.ViewHolder
             ): Int {
-                if (!dd) // setting IDLE setting to disable drag up or down detection
+                if (!isDDropEnabled) // setting IDLE setting to disable drag up or down detection
                     return ACTION_STATE_IDLE
                 return super.getDragDirs(recyclerView, viewHolder)
             }
@@ -160,8 +173,8 @@ class RoadBookFragment : Fragment(), MenuProvider {
                 viewHolder: RecyclerView.ViewHolder
             ): Int {
                 var swipeFlags = ACTION_STATE_SWIPE
-                if (sl) swipeFlags = swipeFlags or LEFT
-                if (sr) swipeFlags = swipeFlags or RIGHT
+                if (isSLEnabled) swipeFlags = swipeFlags or LEFT
+                if (isSREnabled) swipeFlags = swipeFlags or RIGHT
 
                 return swipeFlags
             }
@@ -175,6 +188,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
         private const val SWIPE_L_SHARED_KEY = "SwipeLeftButton"
         private const val SWIPE_R_SHARED_KEY = "SwipeRightButton"
         private const val DRAG_N_DROP_SHARED_KEY = "DragNDropButton"
+        private const val TOUCH_CLICK_SHARED_KEY = "TouchClickButton"
     }
 
     /** Only use that access for testing purpose */
@@ -186,6 +200,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
         saveRadioButtonState(SWIPE_R_SHARED_KEY, R.id.rbSwipeREdition)
         saveRadioButtonState(SWIPE_L_SHARED_KEY, R.id.rbSwipeLDeletion)
         saveRadioButtonState(DRAG_N_DROP_SHARED_KEY, R.id.rbDragDrop)
+        saveRadioButtonState(TOUCH_CLICK_SHARED_KEY, R.id.rbTouchClick)
         super.onDestroyView()
     }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -138,6 +138,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
             true
         }
     }
+
     override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
         // Needed to have the onSupportNavigateUp() called
         // when clicking on the home button after an onMenuItemSelected() override

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookTHCallback.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookTHCallback.kt
@@ -72,9 +72,9 @@ abstract class RoadBookTHCallback() :
         }
     }
 
-    @SuppressLint("NotifyDataSetChanged")
+    @SuppressLint("NotifyDataSetChanged") // Don't update the front-end, want to keep the hole
     override fun onSwiped(viewHolder: ViewHolder, direction: Int) {
-        when(direction){
+        when(direction) {
             RIGHT -> { // Record Edition
                 editOnSwipeRight(viewHolder)
             }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookTHCallback.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookTHCallback.kt
@@ -1,0 +1,82 @@
+package com.github.factotum_sdp.factotum.ui.roadbook
+
+import android.annotation.SuppressLint
+import android.app.AlertDialog
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.ItemTouchHelper
+import androidx.recyclerview.widget.RecyclerView
+import com.github.factotum_sdp.factotum.R
+import com.google.android.material.snackbar.Snackbar
+
+abstract class RoadBookTHCallback() :
+    ItemTouchHelper.SimpleCallback(
+    ItemTouchHelper.UP or ItemTouchHelper.DOWN,
+    ItemTouchHelper.RIGHT or ItemTouchHelper.LEFT or ItemTouchHelper.ACTION_STATE_SWIPE) {
+
+    abstract fun getHost(): Fragment
+    abstract fun getRbViewModel(): RoadBookViewModel
+    abstract fun getRecyclerView(): RecyclerView
+
+    override fun onMove(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        target: RecyclerView.ViewHolder
+    ): Boolean {
+        try {
+            val fromPosition = viewHolder.absoluteAdapterPosition
+            val toPosition = target.absoluteAdapterPosition
+
+            // Only the front-end is updated when drag-travelling for a smoother UX
+            recyclerView.adapter?.notifyItemMoved(fromPosition, toPosition)
+
+            // Back-end swap job not published here, @see pushSwapsResult() call
+            if (toPosition < fromPosition) {
+                getRbViewModel().swapRecords(toPosition, fromPosition - 1)
+            } else {
+                getRbViewModel().swapRecords(fromPosition, toPosition - 1)
+            }
+
+            return true
+        } catch (e: java.lang.Exception) {
+            return false
+        }
+    }
+
+    // Hacky move to update the ViewModel only when the Drag&Drop has ended
+    override fun onSelectedChanged(viewHolder: RecyclerView.ViewHolder?, actionState: Int) {
+        super.onSelectedChanged(viewHolder, actionState)
+
+        if (actionState == ItemTouchHelper.ACTION_STATE_IDLE) {
+            // Push only if the STATE_IDLE arrives after a Drag and Drop move
+            getRbViewModel().pushSwapsResult()
+        }
+    }
+
+    @SuppressLint("NotifyDataSetChanged")
+    override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {
+        when(direction){
+            ItemTouchHelper.RIGHT -> { // Record Edition
+                DRecordAlertDialogBuilder(getHost().requireContext(), getHost(),
+                    getRbViewModel(), getRecyclerView())
+                    .forExistingRecordEdition(viewHolder)
+                    .show()
+            }
+            ItemTouchHelper.LEFT -> { // Record Deletion
+                val position = viewHolder.absoluteAdapterPosition
+                val builder = AlertDialog.Builder(getHost().requireContext())
+                builder.setTitle(getHost().getString(R.string.delete_dialog_title))
+                builder.setCancelable(false)
+                builder.setPositiveButton(getHost().getString(R.string.delete_confirm_button_label)) { _, _ ->
+                    getRbViewModel().deleteRecordAt(position)
+                    Snackbar
+                        .make(getHost().requireView(), getHost().getString(R.string.snap_text_on_rec_delete), 700)
+                        .setAction("Action", null).show()
+                }
+                builder.setNegativeButton(getHost().getString(R.string.delete_cancel_button_label)) { _, _ ->
+                    getRecyclerView().adapter!!.notifyItemChanged(position)
+                }
+                builder.show()
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewAdapter.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewAdapter.kt
@@ -18,7 +18,8 @@ import java.util.*
  * Adapter for the RecyclerView which will display a dynamic list of DestinationRecord
  * Choice of the RecyclerView instead of a ListAdapter for later facilities with drageNdrop
  */
-class RoadBookViewAdapter : RecyclerView.Adapter<RoadBookViewAdapter.RecordViewHolder>() {
+class RoadBookViewAdapter(private val onItemViewHolderL: View.OnClickListener?) :
+    RecyclerView.Adapter<RoadBookViewAdapter.RecordViewHolder>() {
 
     // Call back needed to instantiate the async list attribute
     private val differCallback = object : DiffUtil.ItemCallback<DestinationRecord>(){
@@ -119,10 +120,7 @@ class RoadBookViewAdapter : RecyclerView.Adapter<RoadBookViewAdapter.RecordViewH
         val actions: TextView = itemView.findViewById(R.id.dest_actions)
 
         init {
-            itemView.setOnClickListener {
-                val navController = it.findNavController()
-                navController.navigate(R.id.action_roadBookFragment_to_DRecordDetailsFragment)
-            }
+            itemView.setOnClickListener(onItemViewHolderL)
         }
     }
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewAdapter.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewAdapter.kt
@@ -4,6 +4,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import androidx.navigation.findNavController
 import androidx.recyclerview.widget.AsyncListDiffer
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
@@ -12,7 +13,6 @@ import com.github.factotum_sdp.factotum.data.DestinationRecord.Action
 import com.github.factotum_sdp.factotum.data.DestinationRecord
 import java.text.SimpleDateFormat
 import java.util.*
-import kotlin.collections.HashMap
 
 /**
  * Adapter for the RecyclerView which will display a dynamic list of DestinationRecord
@@ -37,7 +37,8 @@ class RoadBookViewAdapter : RecyclerView.Adapter<RoadBookViewAdapter.RecordViewH
     // Inflate a new view hierarchy according to fragment_destrecord.xml design
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecordViewHolder {
         val view =
-            LayoutInflater.from(parent.context)
+            LayoutInflater
+                .from(parent.context)
                 .inflate(R.layout.fragment_destrecord, parent, false)
         return RecordViewHolder(view)
     }
@@ -116,6 +117,12 @@ class RoadBookViewAdapter : RecyclerView.Adapter<RoadBookViewAdapter.RecordViewH
         val waitingTime: TextView = itemView.findViewById(R.id.waiting_time)
         val rate: TextView = itemView.findViewById(R.id.rate)
         val actions: TextView = itemView.findViewById(R.id.dest_actions)
-    }
 
+        init {
+            itemView.setOnClickListener {
+                val navController = it.findNavController()
+                navController.navigate(R.id.action_roadBookFragment_to_DRecordDetailsFragment)
+            }
+        }
+    }
 }

--- a/app/src/main/res/layout/fragment_drecord_details.xml
+++ b/app/src/main/res/layout/fragment_drecord_details.xml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/fragment_drecord_details_directors_parent"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:visibility="visible"
+    tools:context=".ui.roadbook.DRecordDetailsFragment"
     tools:visibility="visible">
 
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/fragmentContainerView"
-        android:name="com.github.factotum_sdp.factotum.ui.directory.ContactDetailsFragment"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_drecord_details.xml
+++ b/app/src/main/res/layout/fragment_drecord_details.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/fragment_drecord_details_directors_parent"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:visibility="visible"
+    tools:visibility="visible">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragmentContainerView"
+        android:name="com.github.factotum_sdp.factotum.ui.directory.ContactDetailsFragment"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/switch_item.xml
+++ b/app/src/main/res/layout/switch_item.xml
@@ -1,0 +1,11 @@
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <Switch
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_centerVertical="true" />
+</RelativeLayout>

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -12,6 +12,9 @@
         <item
             android:id="@+id/rbSwipeREdition"
             android:title="@string/rb_label_swiper_edition" />
+        <item
+            android:id="@+id/rbTouchClick"
+            android:title="@string/rb_label_touch_click" />
     </group>
 </menu>
 

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -1,4 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:theme="@style/Widget.Material3.PopupMenu">
+    <group
+        android:checkableBehavior="all"
+        android:menuCategory="container">
+        <item
+            android:id="@+id/rbDragDrop"
+            android:title="@string/rb_label_dragdrop" />
+        <item
+            android:id="@+id/rbSwipeLDeletion"
+            android:title="@string/rb_label_swipel_deletion" />
+        <item
+            android:id="@+id/rbSwipeREdition"
+            android:title="@string/rb_label_swiper_edition" />
+    </group>
 </menu>
+

--- a/app/src/main/res/menu/main.xml
+++ b/app/src/main/res/menu/main.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:theme="@style/Widget.Material3.PopupMenu">
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
     <group
         android:checkableBehavior="all"
-        android:menuCategory="container">
+        android:menuCategory="alternative">
         <item
             android:id="@+id/rbDragDrop"
             android:title="@string/rb_label_dragdrop" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -23,13 +23,22 @@
 
         <action
             android:id="@+id/action_SecondFragment_to_FirstFragment"
-            app:destination="@id/routeFragment" />
+            app:destination="@id/routeFragment"/>
     </fragment>
     <fragment
         android:id="@+id/roadBookFragment"
         android:name="com.github.factotum_sdp.factotum.ui.roadbook.RoadBookFragment"
         android:label="RoadBook"
-        tools:layout="@layout/fragment_roadbook" />
+        tools:layout="@layout/fragment_roadbook">
+        <action
+            android:id="@+id/action_roadBookFragment_to_DRecordDetailsFragment"
+            app:destination="@id/dRecordDetailsFragment"/>
+    </fragment>
+    <fragment
+        android:id="@+id/dRecordDetailsFragment"
+        android:name="com.github.factotum_sdp.factotum.ui.roadbook.DRecordDetailsFragment"
+        android:label="Record details"
+        tools:layout="@layout/fragment_drecord_details"/>
     <fragment
         android:id="@+id/pictureFragment"
         android:name="com.github.factotum_sdp.factotum.ui.picture.PictureFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,8 +75,8 @@
     <string name="file_provider">"com.github.factotum_sdp.factotum.file-provider"</string>
     <string name="camera_permission_not_granted">Permission needed to take a photo</string>
 
-    <string name="rb_label_swiper_edition">SwipeR Editon</string>
-    <string name="rb_label_dragdrop"><![CDATA[Drag&Drop]]></string>
+    <string name="rb_label_swiper_edition">Swipe R. Editon</string>
+    <string name="rb_label_dragdrop"><![CDATA[Drag & Drop]]></string>
     <string name="edit_dialog_cancel_b">cancel</string>
     <string name="edit_dialog_update_b">update</string>
     <string name="menu_view_proof_picture">View Proof Pictures</string>
@@ -87,10 +87,11 @@
     <string name="hint_dialog_rate">Rate</string>
     <string name="hint_dialog_actions">Actions</string>
     <string name="hint_dialog_notes">Notes</string>
-    <string name="rb_label_swipel_deletion">SwipeL Deletion</string>
+    <string name="rb_label_swipel_deletion">Swipe L. Deletion</string>
     <string name="delete_confirm_button_label">Confirm</string>
     <string name="delete_cancel_button_label">Cancel</string>
     <string name="delete_dialog_title">Delete the swiped record ?</string>
     <string name="edit_rejected_snap_label">Wrong format. Edition canceled</string>
     <string name="edit_confirmed_snap_label">Record edited</string>
+    <string name="rb_label_touch_click">Touch click</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -19,6 +19,7 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+
     <style name="Theme.Factotum.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
 
     <style name="Theme.Factotum.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />


### PR DESCRIPTION
Done in that PR :

- More screen control added for the UX : 
  Possibility to set the different Touch features of the RoadBook thanks to some checked buttons displayed in the `OptionMenu`.
- Their checked states are saved in the `SharedPreference` of the device.
- Now a `DestinationRecord` click triggers a navigation to a new `DRecordDetailsFragment`.