### PR TITLE
Feature/skeleton fragment details

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
@@ -93,7 +93,6 @@ class MainActivityTest {
 
     @Test
     fun clickOnRoadBookMenuItemStaysToCorrectFragment() {
-        //onView(withId(R.id.fragment_roadbook_directors_parent)).check(matches(isDisplayed()))
         clickOnAMenuItemLeadsCorrectly(
             R.id.roadBookFragment,
             R.id.fragment_roadbook_directors_parent

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
@@ -92,14 +92,6 @@ class MainActivityTest {
     }
 
     @Test
-    fun clickOnDirectoryMenuItemLeadsToCorrectFragment() {
-        clickOnAMenuItemLeadsCorrectly(
-            R.id.directoryFragment,
-            R.id.fragment_directory_directors_parent
-        )
-    }
-
-    @Test
     fun clickOnRoadBookMenuItemStaysToCorrectFragment() {
         //onView(withId(R.id.fragment_roadbook_directors_parent)).check(matches(isDisplayed()))
         clickOnAMenuItemLeadsCorrectly(

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragmentTest.kt
@@ -1,0 +1,90 @@
+package com.github.factotum_sdp.factotum.ui.roadbook
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.contrib.DrawerActions
+import androidx.test.espresso.matcher.ViewMatchers.*
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.factotum_sdp.factotum.MainActivity
+import com.github.factotum_sdp.factotum.R
+import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
+import com.github.factotum_sdp.factotum.ui.roadbook.TouchCustomMoves.swipeRightTheRecordAt
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class DRecordDetailsFragmentTest {
+
+    @get:Rule
+    var testRule = ActivityScenarioRule(
+        MainActivity::class.java
+    )
+
+    @Before
+    fun toRoadBookFragment() {
+        testRule.scenario.onActivity {
+            setPrefs(RoadBookFragmentTest.SWIPE_L_SHARED_KEY, it, true)
+            setPrefs(RoadBookFragmentTest.SWIPE_R_SHARED_KEY, it, true)
+            setPrefs(RoadBookFragmentTest.DRAG_N_DROP_SHARED_KEY, it, true)
+            setPrefs(RoadBookFragmentTest.TOUCH_CLICK_SHARED_KEY, it, false)
+        }
+        onView(withId(R.id.drawer_layout))
+            .perform(DrawerActions.open())
+        onView(withId(R.id.roadBookFragment))
+            .perform(click())
+    }
+
+    private fun setPrefs(sharedKey: String, activity: MainActivity, value: Boolean) {
+        val sp = activity.getSharedPreferences(sharedKey, Context.MODE_PRIVATE)
+        val edit = sp.edit()
+        edit.putBoolean(sharedKey, value)
+        edit.apply()
+    }
+
+    @Test
+    fun displayedDetailsFragMatchTheClickedRecord() {
+        Espresso.openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext())
+        onView(withText(R.string.rb_label_touch_click)).perform(click())
+        val destID = DestinationRecords.RECORDS[2].destID
+        onView(withText(destID)).perform(click())
+        onView(withId(R.id.fragment_drecord_details_directors_parent)).check(matches(isDisplayed()))
+        onView(withText(DestinationRecords.RECORDS[2].destID)).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun displayedDetailsAreStillCorrectAfterEdit() {
+        swipeRightTheRecordAt(2)
+        val destID = "New"
+        val notes = "Some notes about how SDP is fun"
+        // Edit all fields :
+        onView(withId(R.id.autoCompleteClientID))
+            .perform(
+                click(),
+                clearText(),
+                typeText("$destID "),
+                closeSoftKeyboard()
+            )
+
+        onView(withId(R.id.editTextNotes))
+            .perform(
+                click(),
+                typeText(notes),
+                closeSoftKeyboard()
+            )
+        onView(withText(R.string.edit_dialog_update_b)).perform(click())
+        Espresso.openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext())
+        onView(withText(R.string.rb_label_touch_click)).perform(click())
+        onView(withText("$destID#1")).perform(click())
+        onView(withId(R.id.fragment_drecord_details_directors_parent)).check(matches(isDisplayed()))
+        onView(withText(destID)).check(matches(isDisplayed()))
+        onView(withText(notes)).check(matches(isDisplayed()))
+    }
+}

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
@@ -45,10 +45,10 @@ class RoadBookFragmentTest {
 
     companion object {
 
-        private const val SWIPE_L_SHARED_KEY = "SwipeLeftButton"
-        private const val SWIPE_R_SHARED_KEY = "SwipeRightButton"
-        private const val DRAG_N_DROP_SHARED_KEY = "DragNDropButton"
-        private const val TOUCH_CLICK_SHARED_KEY = "TouchClickButton"
+        const val SWIPE_L_SHARED_KEY = "SwipeLeftButton"
+        const val SWIPE_R_SHARED_KEY = "SwipeRightButton"
+        const val DRAG_N_DROP_SHARED_KEY = "DragNDropButton"
+        const val TOUCH_CLICK_SHARED_KEY = "TouchClickButton"
 
         @BeforeClass
         @JvmStatic

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
@@ -20,6 +20,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
 import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
+import com.github.factotum_sdp.factotum.ui.roadbook.TouchCustomMoves.swipeLeftTheRecordAt
+import com.github.factotum_sdp.factotum.ui.roadbook.TouchCustomMoves.swipeRightTheRecordAt
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import org.hamcrest.CoreMatchers.startsWith
@@ -41,10 +43,10 @@ class RoadBookFragmentTest {
     )
 
     companion object {
-        private const val SWIPE_L_SHARED_KEY = "SwipeLeftButton"
-        private const val SWIPE_R_SHARED_KEY = "SwipeRightButton"
-        private const val DRAG_N_DROP_SHARED_KEY = "DragNDropButton"
-        private const val TOUCH_CLICK_SHARED_KEY = "TouchClickButton"
+        const val SWIPE_L_SHARED_KEY = "SwipeLeftButton"
+        const val SWIPE_R_SHARED_KEY = "SwipeRightButton"
+        const val DRAG_N_DROP_SHARED_KEY = "DragNDropButton"
+        const val TOUCH_CLICK_SHARED_KEY = "TouchClickButton"
     }
     private fun setPrefs(sharedKey: String, activity: MainActivity, value: Boolean) {
         val sp = activity.getSharedPreferences(sharedKey, Context.MODE_PRIVATE)
@@ -528,36 +530,5 @@ class RoadBookFragmentTest {
             .substringBeforeLast(":")
             .substringBeforeLast(":")
     }
-    private fun swipeRightTheRecordAt(pos: Int) {
-        swipeSlowActionOnRecyclerList(pos, 0.5f, 1f, 2f, 1f)
-    }
 
-    private fun swipeLeftTheRecordAt(pos: Int) {
-        swipeSlowActionOnRecyclerList(pos, 0.5f, 1f, -1f, 1f)
-    }
-
-    private fun swipeSlowActionOnRecyclerList(pos: Int, startX: Float, startY: Float,
-                                                        endX: Float, endY: Float) {
-        onView(withId(R.id.list)).perform(
-            longClick(),
-            RecyclerViewActions.actionOnItemAtPosition<RoadBookViewAdapter.RecordViewHolder>(
-                pos, GeneralSwipeAction(
-                    Swipe.SLOW,
-                    {
-                        val xy = IntArray(2).also { ar -> it.getLocationOnScreen(ar) }
-                        val x = xy[0] + (it.width - 1) * startX
-                        val y = xy[1] + (it.height - 1) * startY
-                        floatArrayOf(x, y)
-                    },
-                    {
-                        val xy = IntArray(2).also { ar -> it.getLocationOnScreen(ar) }
-                        val x = xy[0] + (it.width - 1) * endX
-                        val y = xy[1] + (it.height - 1) * endY
-                        floatArrayOf(x, y)
-                    },
-                    Press.PINPOINT
-                )
-            )
-        )
-    }
 }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/TouchCustomMoves.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/TouchCustomMoves.kt
@@ -1,0 +1,49 @@
+package com.github.factotum_sdp.factotum.ui.roadbook
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.GeneralSwipeAction
+import androidx.test.espresso.action.Press
+import androidx.test.espresso.action.Swipe
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.contrib.RecyclerViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import com.github.factotum_sdp.factotum.R
+
+/**
+ * Custom touch screen moves for Espresso testing purpose
+ */
+object TouchCustomMoves {
+
+    fun swipeRightTheRecordAt(pos: Int) {
+        swipeSlowActionOnRecyclerList(pos, 0.5f, 1f, 2f, 1f)
+    }
+
+    fun swipeLeftTheRecordAt(pos: Int) {
+        swipeSlowActionOnRecyclerList(pos, 0.5f, 1f, -1f, 1f)
+    }
+
+    private fun swipeSlowActionOnRecyclerList(pos: Int, startX: Float, startY: Float,
+                                              endX: Float, endY: Float) {
+        Espresso.onView(ViewMatchers.withId(R.id.list)).perform(
+            ViewActions.longClick(),
+            RecyclerViewActions.actionOnItemAtPosition<RoadBookViewAdapter.RecordViewHolder>(
+                pos, GeneralSwipeAction(
+                    Swipe.SLOW,
+                    {
+                        val xy = IntArray(2).also { ar -> it.getLocationOnScreen(ar) }
+                        val x = xy[0] + (it.width - 1) * startX
+                        val y = xy[1] + (it.height - 1) * startY
+                        floatArrayOf(x, y)
+                    },
+                    {
+                        val xy = IntArray(2).also { ar -> it.getLocationOnScreen(ar) }
+                        val x = xy[0] + (it.width - 1) * endX
+                        val y = xy[1] + (it.height - 1) * endY
+                        floatArrayOf(x, y)
+                    },
+                    Press.PINPOINT
+                )
+            )
+        )
+    }
+}

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/DestinationRecord.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/DestinationRecord.kt
@@ -25,6 +25,15 @@ data class DestinationRecord(
     val notes: String
 ){
     companion object {
+
+        /**
+         * Usual String Format to display a Date object belonging to a DestinationRecord
+         *
+         * Format : "HH:MM:SS AM-PM" / if timeStamp Date is null : _
+         *
+         * @param timeStamp: Date?
+         * @return the timeStamp String format
+         */
         fun timeStampFormat(timeStamp: Date?): String {
             val result =
                 timeStamp?.let {
@@ -33,9 +42,21 @@ data class DestinationRecord(
             return result
         }
 
+        /**
+         * Usual String Format to display a list of Action objects
+         *
+         * The same Action object occurrences in a List<Action>, are collected to be displayed
+         * in a parenthesis format with '|' as separator.
+         *
+         * Example for a List(PICK, CONTACT, PICK) : (contact, pick x2)
+         *
+         * @param actions: List<Action>
+         * @return the actions String format
+         */
         fun actionsFormat(actions: List<Action>): String {
+
             val actionsWithOcc: EnumMap<Action, Int> = EnumMap(Action::class.java)
-            actions.forEach {
+            actions.forEach {// Collect the occurrences
                 actionsWithOcc.compute(it) { _, occ ->
                     var newOcc = occ ?: 0
                     ++newOcc
@@ -43,7 +64,7 @@ data class DestinationRecord(
             }
             val actionsFormatList = actionsWithOcc.map {
                 if (it.value == 1)
-                    it.key.toString()
+                    it.key.toString()// If only one occurrences do not display the x character
                 else
                     "${it.key} x${it.value}"
             }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/DestinationRecord.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/DestinationRecord.kt
@@ -1,6 +1,7 @@
 package com.github.factotum_sdp.factotum.data
 
-import java.util.Date
+import java.text.SimpleDateFormat
+import java.util.*
 
 /**
  * Data design of a Destination Record
@@ -23,6 +24,32 @@ data class DestinationRecord(
     val actions: List<Action>,
     val notes: String
 ){
+    companion object {
+        fun timeStampFormat(timeStamp: Date?): String {
+            val result =
+                timeStamp?.let {
+                    SimpleDateFormat.getTimeInstance().format(it)
+                } ?: "_"
+            return result
+        }
+
+        fun actionsFormat(actions: List<Action>): String {
+            val actionsWithOcc: EnumMap<Action, Int> = EnumMap(Action::class.java)
+            actions.forEach {
+                actionsWithOcc.compute(it) { _, occ ->
+                    var newOcc = occ ?: 0
+                    ++newOcc
+                }
+            }
+            val actionsFormatList = actionsWithOcc.map {
+                if (it.value == 1)
+                    it.key.toString()
+                else
+                    "${it.key} x${it.value}"
+            }
+            return actionsFormatList.joinToString("| ", "(", ")")
+        }
+    }
     /**
      * The possible actions to achieve on a destination
      */

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
@@ -19,7 +19,7 @@ class DRecordDetailsFragment: Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.fragment_drecord_details, container, false)
-        val arg = arguments?.getString("destID") ?: "UNKNOWN"
+        val arg = arguments?.getString(RoadBookFragment.DEST_ID_NAV_ARG_KEY) ?: "UNKNOWN"
         rbViewModel.recordsListState.value?.let {
             val rec = it.first { d -> d.destID == arg }
             setEditTexts(rec, view)

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
@@ -8,6 +8,7 @@ import android.widget.EditText
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import com.github.factotum_sdp.factotum.R
+import com.github.factotum_sdp.factotum.data.DestinationRecord
 
 class DRecordDetailsFragment: Fragment() {
 
@@ -18,13 +19,26 @@ class DRecordDetailsFragment: Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.fragment_drecord_details, container, false)
-
-        val arg = arguments?.getInt("RecPos") ?: 0
-        val list = rbViewModel.recordsListState.value!! //todo better exceptions handling
-        val rec = list[arg]
-        val textView: EditText = view.findViewById(R.id.editTextTextMultiLine)
-        textView.setText(rec.notes)
+        val arg = arguments?.getString("destID") ?: "UNKNOWN"
+        rbViewModel.recordsListState.value?.let {
+            val rec = it.first { d -> d.destID == arg }
+            setEditTexts(rec, view)
+        }
 
         return view
+    }
+
+    private fun setEditTexts(rec: DestinationRecord, view: View) {
+        setEditText(rec.destID, R.id.editTextDestID, view)
+        setEditText(rec.clientID, R.id.editTextClientID, view)
+        setEditText(DestinationRecord.timeStampFormat(rec.timeStamp), R.id.editTextTimestamp, view)
+        setEditText(rec.waitingTime.toString(), R.id.editTextWaitingTime, view)
+        setEditText(rec.rate.toString(), R.id.editTextRate, view)
+        setEditText(DestinationRecord.actionsFormat(rec.actions), R.id.editTextActions, view)
+        setEditText(rec.notes, R.id.editTextNotes, view)
+    }
+    private fun setEditText(format: String, id: Int, view: View) {
+        val editText = view.findViewById<EditText>(id)
+        editText.setText(format)
     }
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
@@ -4,16 +4,27 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import com.github.factotum_sdp.factotum.R
 
 class DRecordDetailsFragment: Fragment() {
+
+    private val rbViewModel: RoadBookViewModel by activityViewModels()
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.fragment_drecord_details, container, false)
+
+        val arg = arguments?.getInt("RecPos") ?: 0
+        val list = rbViewModel.recordsListState.value!! //todo better exceptions handling
+        val rec = list[arg]
+        val textView: EditText = view.findViewById(R.id.editTextTextMultiLine)
+        textView.setText(rec.notes)
+
         return view
     }
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -7,11 +7,9 @@ import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.findNavController
 import androidx.recyclerview.widget.*
 import androidx.recyclerview.widget.ItemTouchHelper.*
-import androidx.recyclerview.widget.RecyclerView.OnItemTouchListener
 import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
 import com.google.android.material.floatingactionbutton.FloatingActionButton
@@ -25,7 +23,9 @@ class RoadBookFragment : Fragment(), MenuProvider {
     private lateinit var rbRecyclerView: RecyclerView
     private lateinit var fragMenu: Menu
     private val rbViewModel: RoadBookViewModel by activityViewModels() {
-        RoadBookViewModel.RoadBookViewModelFactory((activity as MainActivity).getDatabaseRef().child(ROADBOOK_DB_PATH))
+        RoadBookViewModel.RoadBookViewModelFactory(
+            (activity as MainActivity).getDatabaseRef().child(ROADBOOK_DB_PATH)
+        )
     }
 
     // Checked OptionMenu States with default values
@@ -63,7 +63,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
         super.onPause()
     }
 
-    private fun setOnDRecordClickListener(): (Int) -> View.OnClickListener {
+    private fun setOnDRecordClickListener(): (String) -> View.OnClickListener {
         return {
             View.OnClickListener { v ->
                 if(isTClickEnabled) {
@@ -71,7 +71,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
                         ?.findNavController()
                         ?.navigate(R.id.action_roadBookFragment_to_DRecordDetailsFragment,
                             Bundle().apply {
-                                putInt("RecPos", it)
+                                putString("destID", it)
                             }
                         )
                 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -24,7 +24,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
     private lateinit var fragMenu: Menu
     private val rbViewModel: RoadBookViewModel by activityViewModels() {
         RoadBookViewModel.RoadBookViewModelFactory(
-            (activity as MainActivity).getDatabaseRef().child(ROADBOOK_DB_PATH)
+            MainActivity.getDatabase().reference.child(ROADBOOK_DB_PATH)
         )
     }
 
@@ -71,7 +71,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
                         ?.findNavController()
                         ?.navigate(R.id.action_roadBookFragment_to_DRecordDetailsFragment,
                             Bundle().apply {
-                                putString("destID", it)
+                                putString(DEST_ID_NAV_ARG_KEY, it)
                             }
                         )
                 }
@@ -200,6 +200,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
         private const val SWIPE_R_SHARED_KEY = "SwipeRightButton"
         private const val DRAG_N_DROP_SHARED_KEY = "DragNDropButton"
         private const val TOUCH_CLICK_SHARED_KEY = "TouchClickButton"
+        const val DEST_ID_NAV_ARG_KEY = "destID"
     }
 
     /** Only use that access for testing purpose */

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.*
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.ViewModelProvider
 import androidx.navigation.findNavController
@@ -21,9 +22,11 @@ import com.google.android.material.floatingactionbutton.FloatingActionButton
  */
 class RoadBookFragment : Fragment(), MenuProvider {
 
-    private lateinit var rbViewModel: RoadBookViewModel
     private lateinit var rbRecyclerView: RecyclerView
     private lateinit var fragMenu: Menu
+    private val rbViewModel: RoadBookViewModel by activityViewModels() {
+        RoadBookViewModel.RoadBookViewModelFactory((activity as MainActivity).getDatabaseRef().child(ROADBOOK_DB_PATH))
+    }
 
     // Checked OptionMenu States with default values
     // overridden by the device saved SharedPreference
@@ -38,9 +41,6 @@ class RoadBookFragment : Fragment(), MenuProvider {
 
         val view = inflater.inflate(R.layout.fragment_roadbook, container, false)
         val adapter = RoadBookViewAdapter(setOnDRecordClickListener())
-        val dbRef = (activity as MainActivity).getDatabaseRef().child(ROADBOOK_DB_PATH)
-        val rbFact = RoadBookViewModel.RoadBookViewModelFactory(dbRef)
-        rbViewModel = ViewModelProvider(this, rbFact)[RoadBookViewModel::class.java]
 
         // Observe the roadbook ViewModel, to detect data changes
         // and update the displayed RecyclerView accordingly
@@ -63,12 +63,18 @@ class RoadBookFragment : Fragment(), MenuProvider {
         super.onPause()
     }
 
-    private fun setOnDRecordClickListener(): View.OnClickListener {
-        return View.OnClickListener { v ->
-            if(isTClickEnabled) {
-                v
-                    ?.findNavController()
-                    ?.navigate(R.id.action_roadBookFragment_to_DRecordDetailsFragment)
+    private fun setOnDRecordClickListener(): (Int) -> View.OnClickListener {
+        return {
+            View.OnClickListener { v ->
+                if(isTClickEnabled) {
+                    v
+                        ?.findNavController()
+                        ?.navigate(R.id.action_roadBookFragment_to_DRecordDetailsFragment,
+                            Bundle().apply {
+                                putInt("RecPos", it)
+                            }
+                        )
+                }
             }
         }
     }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewAdapter.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewAdapter.kt
@@ -1,5 +1,6 @@
 package com.github.factotum_sdp.factotum.ui.roadbook
 
+import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -18,7 +19,7 @@ import java.util.*
  * Adapter for the RecyclerView which will display a dynamic list of DestinationRecord
  * Choice of the RecyclerView instead of a ListAdapter for later facilities with drageNdrop
  */
-class RoadBookViewAdapter(private val onItemViewHolderL: View.OnClickListener?) :
+class RoadBookViewAdapter(private val onItemViewHolderLFromClientId: (Int) -> View.OnClickListener?) :
     RecyclerView.Adapter<RoadBookViewAdapter.RecordViewHolder>() {
 
     // Call back needed to instantiate the async list attribute
@@ -54,6 +55,7 @@ class RoadBookViewAdapter(private val onItemViewHolderL: View.OnClickListener?) 
     // Bind each displayed Record to the corresponding current async list slot
     override fun onBindViewHolder(holder: RecordViewHolder, position: Int) {
         val item = asyncList.currentList[position]
+        val itemView = holder.itemView
         val context = holder.itemView.context
 
         // Format and bind the TextViews
@@ -66,6 +68,8 @@ class RoadBookViewAdapter(private val onItemViewHolderL: View.OnClickListener?) 
             rateStringFormat(item.rate, context.getString(R.string.rate_text_view))
         holder.actions.text =
             actionsStringFormat(item.actions, context.getString(R.string.actions_text_view))
+
+        itemView.setOnClickListener(onItemViewHolderLFromClientId(position))
     }
 
     private fun rateStringFormat(rate: Int, label: String): String {
@@ -116,9 +120,5 @@ class RoadBookViewAdapter(private val onItemViewHolderL: View.OnClickListener?) 
         val waitingTime: TextView = itemView.findViewById(R.id.waiting_time)
         val rate: TextView = itemView.findViewById(R.id.rate)
         val actions: TextView = itemView.findViewById(R.id.dest_actions)
-
-        init {
-            itemView.setOnClickListener(onItemViewHolderL)
-        }
     }
 }

--- a/app/src/main/res/layout/fragment_drecord_details.xml
+++ b/app/src/main/res/layout/fragment_drecord_details.xml
@@ -14,91 +14,93 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="16dp">
+        android:padding="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Destination ID"
-            android:textSize="16sp"/>
+            android:textSize="16sp" />
 
         <EditText
             android:id="@+id/editTextDestID"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"/>
+            android:enabled="false" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Client ID"
-            android:textSize="16sp"/>
+            android:textSize="16sp" />
 
         <EditText
             android:id="@+id/editTextClientID"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"/>
+            android:enabled="false" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Timestamp"
-            android:textSize="16sp"/>
+            android:textSize="16sp" />
 
         <EditText
             android:id="@+id/editTextTimestamp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"/>
+            android:enabled="false" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Waiting Time"
-            android:textSize="16sp"/>
+            android:textSize="16sp" />
 
         <EditText
             android:id="@+id/editTextWaitingTime"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"/>
+            android:enabled="false" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Rate"
-            android:textSize="16sp"/>
+            android:textSize="16sp" />
 
         <EditText
             android:id="@+id/editTextRate"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"/>
+            android:enabled="false" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Actions"
-            android:textSize="16sp"/>
+            android:textSize="16sp" />
 
         <EditText
             android:id="@+id/editTextActions"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"/>
+            android:enabled="false" />
 
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:text="Notes"
-            android:textSize="16sp"/>
+            android:textSize="16sp" />
 
         <EditText
             android:id="@+id/editTextNotes"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:enabled="false"/>
-
+            android:enabled="false" />
     </LinearLayout>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_drecord_details.xml
+++ b/app/src/main/res/layout/fragment_drecord_details.xml
@@ -9,4 +9,16 @@
     tools:context=".ui.roadbook.DRecordDetailsFragment"
     tools:visibility="visible">
 
+
+    <EditText
+        android:id="@+id/editTextTextMultiLine"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="100dp"
+        android:layout_marginTop="343dp"
+        android:ems="10"
+        android:gravity="start|top"
+        android:inputType="textMultiLine"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_drecord_details.xml
+++ b/app/src/main/res/layout/fragment_drecord_details.xml
@@ -10,15 +10,95 @@
     tools:visibility="visible">
 
 
-    <EditText
-        android:id="@+id/editTextTextMultiLine"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="100dp"
-        android:layout_marginTop="343dp"
-        android:ems="10"
-        android:gravity="start|top"
-        android:inputType="textMultiLine"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        android:orientation="vertical"
+        android:padding="16dp">
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Destination ID"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/editTextDestID"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Client ID"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/editTextClientID"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Timestamp"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/editTextTimestamp"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Waiting Time"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/editTextWaitingTime"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Rate"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/editTextRate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Actions"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/editTextActions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"/>
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Notes"
+            android:textSize="16sp"/>
+
+        <EditText
+            android:id="@+id/editTextNotes"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:enabled="false"/>
+
+    </LinearLayout>
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Done in that PR : 

- RoadBook View Model's data is now accessible by some other Fragment thanks to the `by activityViewModel()` property.
- Navigation to DRecordDetailsFragment has now an argument which is the destID of the record clicked on.
- Basic display of the DestinationRecord fields is done in that new Fragment.

True Fragment UI and content will be done in the next sprint as it needs a more correlated back-end, and parts of the things, we want to display concerns several modules implemented at the end of this sprint. 

Note I didn't put the label of the EditText fields in the String Ressources, as it will probably not be kept.