### PR TITLE
Force default Locale to Locale.ENGLISH

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
@@ -241,6 +241,7 @@ class RoadBookFragmentTest {
         swipeRightTheRecordAt(3) // edit one record displayed below which has another clientID
         onView(withId(R.id.autoCompleteClientID)).perform(clearText(), typeText(clientID)) // set for the same client that different record
         onView(withText(R.string.edit_dialog_update_b)).perform(click())
+        Thread.sleep(2000)
         onView(withText("$clientID#2")).check(matches(isDisplayed())) // unique destID is computed
     }
 
@@ -286,6 +287,7 @@ class RoadBookFragmentTest {
         onView(withId(R.id.editTextTimestamp)).perform(click())
         onView(withText(timePickerCancelBLabel)).perform(click())
         onView(withText(R.string.edit_dialog_update_b)).perform(click())
+        Thread.sleep(2000)
 
         onView(withText(startsWith("arrival : ${timestampUntilHourFormat(cal)}"))).check(doesNotExist())
     }
@@ -471,6 +473,7 @@ class RoadBookFragmentTest {
         onView(withText(R.string.edit_dialog_cancel_b)).perform(click())
 
         // Navigation on Click disabled
+        Thread.sleep(2000)
         onView(withText(DestinationRecords.RECORDS[2].destID)).perform(click())
         onView(withId(R.id.fragment_drecord_details_directors_parent)).check(doesNotExist())
 
@@ -498,6 +501,7 @@ class RoadBookFragmentTest {
         onView(withText(R.string.edit_dialog_cancel_b)).perform(click())
 
         // Navigation on Click disabled
+        Thread.sleep(2000)
         onView(withText(DestinationRecords.RECORDS[2].destID)).perform(click())
         onView(withId(R.id.fragment_drecord_details_directors_parent)).check(doesNotExist())
     }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/DestinationRecord.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/DestinationRecord.kt
@@ -1,5 +1,6 @@
 package com.github.factotum_sdp.factotum.data
 
+import java.text.DateFormat
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -37,7 +38,7 @@ data class DestinationRecord(
         fun timeStampFormat(timeStamp: Date?): String {
             val result =
                 timeStamp?.let {
-                    SimpleDateFormat.getTimeInstance().format(it)
+                    SimpleDateFormat.getTimeInstance(DateFormat.DEFAULT, Locale.ENGLISH).format(it)
                 } ?: "_"
             return result
         }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewModel.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.ViewModelProvider
 import com.github.factotum_sdp.factotum.data.DestinationRecord
 import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.google.firebase.database.DatabaseReference
+import java.text.DateFormat
 import java.text.SimpleDateFormat.getDateInstance
 import java.util.*
 import kotlin.collections.ArrayList
@@ -30,8 +31,9 @@ class RoadBookViewModel(_dbRef: DatabaseReference) : ViewModel() {
 
     init {
         val date = Calendar.getInstance().time
+        val dateRef = getDateInstance(DateFormat.DEFAULT, Locale.ENGLISH).format(date)
         dbRef = _dbRef // ref path to register all back-ups from this RoadBook
-                .child(getDateInstance().format(date))
+                .child(dateRef)
                 //.child(getTimeInstance().format(date).plus(Random.nextInt().toString()))
                 // Let uncommented for testing purpose. Uncomment it for back-up uniqueness in the DB
         // Only for demo purpose :


### PR DESCRIPTION
- Force default Locale on format calls to `Locale.ENGLISH`
- Thread.sleep added for 3 flaky tests on CI (Related to the RoadBook, add a small delta time to be sure updates are displayed on screen)