### PR TITLE
Feature/link drecord picture

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
@@ -38,6 +38,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 const val LOGIN_REFRESH_TIME = 3000L
+const val DRAWER_REFRESH_TIME = 1000L
+
 @RunWith(AndroidJUnit4::class)
 class MainActivityTest {
 
@@ -212,6 +214,8 @@ class MainActivityTest {
 
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
 
+        Thread.sleep(DRAWER_REFRESH_TIME)
+
         // Check that the menu items are displayed
         onView(withText("RoadBook")).check(matches(isDisplayed()))
         onView(withText("Directory")).check(matches(isDisplayed()))
@@ -225,6 +229,8 @@ class MainActivityTest {
         Thread.sleep(LOGIN_REFRESH_TIME)
 
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
+
+        Thread.sleep(DRAWER_REFRESH_TIME)
 
         // Check that the menu items are displayed
         onView(withText("RoadBook")).check(doesNotExist())

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
@@ -46,9 +46,6 @@ class MainActivityTest {
         MainActivity::class.java
     )
 
-    @get:Rule
-    val permissionsRule: GrantPermissionRule = GrantPermissionRule.grant(Manifest.permission.CAMERA)
-
     companion object {
         @BeforeClass
         @JvmStatic
@@ -138,30 +135,6 @@ class MainActivityTest {
     }
 
     @Test
-    fun clickOnPictureMenuItemLeadsToCorrectFragmentAnd() {
-        Intents.init()
-        val device = UiDevice.getInstance(getInstrumentation())
-
-        onView(withId(R.id.drawer_layout))
-            .perform(DrawerActions.open())
-        onView(withId(R.id.pictureFragment))
-            .perform(click())
-        // Check that is open the camera
-
-        // Create an IntentMatcher to capture the intent that should open the camera app
-        val expectedIntent = allOf(hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
-
-        Thread.sleep(5000)
-
-        // Click on the camera shutter button
-        device.executeShellCommand("input keyevent 27")
-
-        // Use Intents.intended() to check that the captured intent matches the expected intent
-        Intents.intended(expectedIntent)
-        Intents.release()
-    }
-
-    @Test
     fun clickOnMapsMenuItemLeadsToCorrectFragment() {
         clickOnAMenuItemLeadsCorrectly(
             R.id.routeFragment,
@@ -242,7 +215,6 @@ class MainActivityTest {
         // Check that the menu items are displayed
         onView(withText("RoadBook")).check(matches(isDisplayed()))
         onView(withText("Directory")).check(matches(isDisplayed()))
-        onView(withText("Picture")).check(matches(isDisplayed()))
         onView(withText("Maps")).check(matches(isDisplayed()))
         onView(withText("View Proof Pictures")).check(matches(isDisplayed()))
     }
@@ -257,7 +229,6 @@ class MainActivityTest {
         // Check that the menu items are displayed
         onView(withText("RoadBook")).check(doesNotExist())
         onView(withText("Directory")).check(doesNotExist())
-        onView(withText("Picture")).check(doesNotExist())
         onView(withText("Maps")).check(doesNotExist())
         onView(withText("View Proof Pictures")).check(matches(isDisplayed()))
     }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
@@ -54,20 +54,7 @@ class PictureFragmentOfflineTest {
         device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         emptyLocalFiles(picturesDir)
 
-        // Open the drawer
-        onView(withId(R.id.drawer_layout))
-            .perform(DrawerActions.open())
-        onView(withId(R.id.roadBookFragment))
-            .perform(click())
-
-        // Click on one of the roadbook
-        val destID = DestinationRecords.RECORDS[2].destID
-        onView(withText(destID)).perform(click())
-
-        // Go to the picture fragment
-        onView(withId(R.id.viewPager)).perform(swipeLeft())
-        onView(withId(R.id.viewPager)).perform(swipeLeft())
-        onView(withId(R.id.viewPager)).perform(swipeLeft())
+        goToPictureFragment()
 
         // Wait for the camera to open
         Thread.sleep(TIME_WAIT_SHUTTER)

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
@@ -91,11 +91,11 @@ class PictureFragmentOfflineTest {
 
         storage.reference.listAll().addOnSuccessListener { listResult ->
             fail("Should not succeed")
-        }.addOnFailureListener{
-            //Check if there is a file in the local directory
-            picturesDir.listFiles()?.forEach { file ->
-                assertTrue(file.exists())
-            }
         }
+
+        //Check if there is a folder with a file in it
+        val directories = picturesDir.listFiles()?.filter { it.isDirectory } ?: emptyList()
+        assertTrue(directories.isNotEmpty())
+
     }
 }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
@@ -77,14 +77,13 @@ class PictureFragmentOfflineTest {
     @Test
     fun testDoesNotDeleteFileIfUploadFails() {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        val takePictureButton = device.findObject(UiSelector().description("Shutter"))
-        takePictureButton.click()
+        device.executeShellCommand("input keyevent 27")
 
         // Wait for the photo to be taken
         Thread.sleep(TIME_WAIT_DONE_OR_CANCEL)
+
         // Click the button to validate the photo
-        val validateButton = device.findObject(UiSelector().description("Done"))
-        validateButton.click()
+        device.executeShellCommand("input tap 540 2048")
 
         // Wait for the photo to be uploaded
         Thread.sleep(TIME_WAIT_UPLOAD)

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
@@ -11,14 +11,12 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
 import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.ktx.storage
-import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -83,7 +81,9 @@ class PictureFragmentOfflineTest {
         Thread.sleep(TIME_WAIT_DONE_OR_CANCEL)
 
         // Click the button to validate the photo
-        device.executeShellCommand("input tap 540 2048")
+        device.executeShellCommand("input keyevent 61")
+        device.executeShellCommand("input keyevent 61")
+        device.executeShellCommand("input keyevent 62")
 
         // Wait for the photo to be uploaded
         Thread.sleep(TIME_WAIT_UPLOAD)

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
@@ -4,8 +4,12 @@ import android.Manifest
 import android.os.Environment
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.espresso.contrib.DrawerActions
 import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -30,6 +34,7 @@ import java.io.File
 @RunWith(AndroidJUnit4::class)
 class PictureFragmentOfflineTest {
     private lateinit var storage: FirebaseStorage
+    private lateinit var device: UiDevice
     private val externalDir = Environment.getExternalStorageDirectory()
     private val picturesDir = File(externalDir, "/Android/data/com.github.factotum_sdp.factotum/files/Pictures")
 
@@ -46,22 +51,23 @@ class PictureFragmentOfflineTest {
         // Initialize Firebase Storage
         storage = Firebase.storage
         storage.useEmulator("10.0.2.2", 9198)
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
         emptyLocalFiles(picturesDir)
 
         // Open the drawer
-        onView(ViewMatchers.withId(R.id.drawer_layout))
+        onView(withId(R.id.drawer_layout))
             .perform(DrawerActions.open())
-        onView(ViewMatchers.withId(R.id.roadBookFragment))
-            .perform(ViewActions.click())
+        onView(withId(R.id.roadBookFragment))
+            .perform(click())
 
         // Click on one of the roadbook
         val destID = DestinationRecords.RECORDS[2].destID
-        onView(ViewMatchers.withText(destID)).perform(ViewActions.click())
+        onView(withText(destID)).perform(click())
 
         // Go to the picture fragment
-        onView(ViewMatchers.withId(R.id.viewPager)).perform(ViewActions.swipeLeft())
-        onView(ViewMatchers.withId(R.id.viewPager)).perform(ViewActions.swipeLeft())
-        onView(ViewMatchers.withId(R.id.viewPager)).perform(ViewActions.swipeLeft())
+        onView(withId(R.id.viewPager)).perform(swipeLeft())
+        onView(withId(R.id.viewPager)).perform(swipeLeft())
+        onView(withId(R.id.viewPager)).perform(swipeLeft())
 
         // Wait for the camera to open
         Thread.sleep(TIME_WAIT_SHUTTER)
@@ -74,16 +80,14 @@ class PictureFragmentOfflineTest {
 
     @Test
     fun testDoesNotDeleteFileIfUploadFails() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-        device.executeShellCommand("input keyevent 27")
+        // Take a photo
+        triggerShutter(device)
 
         // Wait for the photo to be taken
         Thread.sleep(TIME_WAIT_DONE_OR_CANCEL)
 
         // Click the button to validate the photo
-        device.executeShellCommand("input keyevent 61")
-        device.executeShellCommand("input keyevent 61")
-        device.executeShellCommand("input keyevent 62")
+        triggerDone(device)
 
         // Wait for the photo to be uploaded
         Thread.sleep(TIME_WAIT_UPLOAD)

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
@@ -18,6 +18,7 @@ import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.ktx.storage
+import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
@@ -47,7 +48,6 @@ class PictureFragmentOfflineTest {
         // Initialize Firebase Storage
         storage = Firebase.storage
         storage.useEmulator("10.0.2.2", 9198)
-        emptyFirebaseStorage(storage)
         emptyLocalFiles(picturesDir)
 
         // Open the drawer
@@ -71,7 +71,6 @@ class PictureFragmentOfflineTest {
 
     @After
     fun tearDown() {
-        emptyFirebaseStorage(storage)
         emptyLocalFiles(picturesDir)
     }
 

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
@@ -2,22 +2,12 @@ package com.github.factotum_sdp.factotum.ui.picture
 
 import android.Manifest
 import android.os.Environment
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.action.ViewActions.click
-import androidx.test.espresso.action.ViewActions.swipeLeft
-import androidx.test.espresso.contrib.DrawerActions
-import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.withId
-import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
 import com.github.factotum_sdp.factotum.MainActivity
-import com.github.factotum_sdp.factotum.R
-import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.ktx.storage

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOfflineTest.kt
@@ -14,9 +14,11 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiSelector
 import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
+import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.ktx.storage
+import org.junit.After
 import org.junit.Assert.assertTrue
 import org.junit.Assert.fail
 import org.junit.Before
@@ -46,18 +48,31 @@ class PictureFragmentOfflineTest {
         storage = Firebase.storage
         storage.useEmulator("10.0.2.2", 9198)
         emptyFirebaseStorage(storage)
-
-        // Empty Local Files
         emptyLocalFiles(picturesDir)
 
-        // Launch the fragment
+        // Open the drawer
         onView(ViewMatchers.withId(R.id.drawer_layout))
             .perform(DrawerActions.open())
-        onView(ViewMatchers.withId(R.id.pictureFragment))
+        onView(ViewMatchers.withId(R.id.roadBookFragment))
             .perform(ViewActions.click())
+
+        // Click on one of the roadbook
+        val destID = DestinationRecords.RECORDS[2].destID
+        onView(ViewMatchers.withText(destID)).perform(ViewActions.click())
+
+        // Go to the picture fragment
+        onView(ViewMatchers.withId(R.id.viewPager)).perform(ViewActions.swipeLeft())
+        onView(ViewMatchers.withId(R.id.viewPager)).perform(ViewActions.swipeLeft())
+        onView(ViewMatchers.withId(R.id.viewPager)).perform(ViewActions.swipeLeft())
 
         // Wait for the camera to open
         Thread.sleep(TIME_WAIT_SHUTTER)
+    }
+
+    @After
+    fun tearDown() {
+        emptyFirebaseStorage(storage)
+        emptyLocalFiles(picturesDir)
     }
 
     @Test

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
@@ -33,6 +33,7 @@ class PictureFragmentOnlineTest {
 
     // Those tests need to run with a firebase storage emulator
     private lateinit var storage: FirebaseStorage
+    private lateinit var device : UiDevice
     private val externalDir = Environment.getExternalStorageDirectory()
     private val picturesDir = File(externalDir, "/Android/data/com.github.factotum_sdp.factotum/files/Pictures")
 
@@ -49,6 +50,7 @@ class PictureFragmentOnlineTest {
         storage = Firebase.storage
         storage.useEmulator("10.0.2.2", 9199)
         emptyLocalFiles(picturesDir)
+        device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
         // Open the drawer
         onView(withId(R.id.drawer_layout))
@@ -67,6 +69,9 @@ class PictureFragmentOnlineTest {
 
         // Wait for the camera to open
         Thread.sleep(TIME_WAIT_SHUTTER)
+
+        // Take a photo
+        triggerShutter(device)
     }
 
     @After
@@ -78,18 +83,11 @@ class PictureFragmentOnlineTest {
 
     @Test
     fun testUploadFileCorrectly() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
-        // Click on the shutter button
-        device.executeShellCommand("input keyevent 27")
-
         // Wait for the photo to be taken
         Thread.sleep(TIME_WAIT_DONE_OR_CANCEL)
 
         // Click the button to validate the photo
-        device.executeShellCommand("input keyevent 61")
-        device.executeShellCommand("input keyevent 61")
-        device.executeShellCommand("input keyevent 62")
+        triggerDone(device)
 
         // Wait for the photo to be uploaded
         Thread.sleep(TIME_WAIT_UPLOAD)
@@ -109,19 +107,11 @@ class PictureFragmentOnlineTest {
 
     @Test
     fun testCancelPhoto() {
-        val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-
-        val takePictureButton = device.findObject(UiSelector().description("Shutter"))
-        takePictureButton.click()
-
         // Wait for the photo to be taken
         Thread.sleep(TIME_WAIT_DONE_OR_CANCEL)
 
         // Click the button to cancel the photo
-        device.executeShellCommand("input keyevent 61")
-        device.executeShellCommand("input keyevent 61")
-        device.executeShellCommand("input keyevent 61")
-        device.executeShellCommand("input keyevent 62")
+        triggerCancel(device)
 
         // Wait for the photo to be uploaded
         Thread.sleep(TIME_WAIT_UPLOAD)
@@ -139,4 +129,6 @@ class PictureFragmentOnlineTest {
             fail(except.message)
         }
     }
+
+
 }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
@@ -2,11 +2,7 @@ package com.github.factotum_sdp.factotum.ui.picture
 
 import android.Manifest
 import android.os.Environment
-import android.util.Log
-import androidx.test.core.app.ApplicationProvider
-import androidx.test.espresso.Espresso
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
 import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.espresso.contrib.DrawerActions
@@ -22,8 +18,6 @@ import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
 import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.github.factotum_sdp.factotum.ui.picture.*
-import com.github.factotum_sdp.factotum.ui.roadbook.DRecordDetailsFragmentTest
-import com.github.factotum_sdp.factotum.ui.roadbook.RoadBookFragmentTest
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.ktx.storage
@@ -93,8 +87,9 @@ class PictureFragmentOnlineTest {
         Thread.sleep(TIME_WAIT_DONE_OR_CANCEL)
 
         // Click the button to validate the photo
-        val validateButton = device.findObject(UiSelector().description("Done"))
-        validateButton.click()
+        device.executeShellCommand("input keyevent 61")
+        device.executeShellCommand("input keyevent 61")
+        device.executeShellCommand("input keyevent 62")
 
         // Wait for the photo to be uploaded
         Thread.sleep(TIME_WAIT_UPLOAD)
@@ -123,8 +118,10 @@ class PictureFragmentOnlineTest {
         Thread.sleep(TIME_WAIT_DONE_OR_CANCEL)
 
         // Click the button to cancel the photo
-        val cancelButton = device.findObject(UiSelector().description("Cancel"))
-        cancelButton.click()
+        device.executeShellCommand("input keyevent 61")
+        device.executeShellCommand("input keyevent 61")
+        device.executeShellCommand("input keyevent 61")
+        device.executeShellCommand("input keyevent 62")
 
         // Wait for the photo to be uploaded
         Thread.sleep(TIME_WAIT_UPLOAD)

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
@@ -2,21 +2,12 @@ package com.github.factotum_sdp.factotum.ui.picture
 
 import android.Manifest
 import android.os.Environment
-import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
-import androidx.test.espresso.action.ViewActions.swipeLeft
-import androidx.test.espresso.contrib.DrawerActions
-import androidx.test.espresso.matcher.ViewMatchers
-import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.GrantPermissionRule
 import androidx.test.uiautomator.UiDevice
-import androidx.test.uiautomator.UiSelector
 import com.github.factotum_sdp.factotum.MainActivity
-import com.github.factotum_sdp.factotum.R
-import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.github.factotum_sdp.factotum.ui.picture.*
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
@@ -86,8 +86,8 @@ class PictureFragmentOnlineTest {
     fun testUploadFileCorrectly() {
         val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
-        val takePictureButton = device.findObject(UiSelector().description("Shutter"))
-        takePictureButton.click()
+        // Click on the shutter button
+        device.executeShellCommand("input keyevent 27")
 
         // Wait for the photo to be taken
         Thread.sleep(TIME_WAIT_DONE_OR_CANCEL)

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
@@ -52,20 +52,7 @@ class PictureFragmentOnlineTest {
         emptyLocalFiles(picturesDir)
         device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
 
-        // Open the drawer
-        onView(withId(R.id.drawer_layout))
-            .perform(DrawerActions.open())
-        onView(withId(R.id.roadBookFragment))
-            .perform(ViewActions.click())
-
-        // Click on one of the roadbook
-        val destID = DestinationRecords.RECORDS[2].destID
-        onView(ViewMatchers.withText(destID)).perform(ViewActions.click())
-
-        // Go to the picture fragment
-        onView(withId(R.id.viewPager)).perform(swipeLeft())
-        onView(withId(R.id.viewPager)).perform(swipeLeft())
-        onView(withId(R.id.viewPager)).perform(swipeLeft())
+        goToPictureFragment()
 
         // Wait for the camera to open
         Thread.sleep(TIME_WAIT_SHUTTER)

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentOnlineTest.kt
@@ -40,8 +40,6 @@ class PictureFragmentOnlineTest {
     private lateinit var storage: FirebaseStorage
     private val externalDir = Environment.getExternalStorageDirectory()
     private val picturesDir = File(externalDir, "/Android/data/com.github.factotum_sdp.factotum/files/Pictures")
-    private val drawerOpened = false
-
 
     @get:Rule
     val permissionsRule = GrantPermissionRule.grant(Manifest.permission.CAMERA)
@@ -55,7 +53,7 @@ class PictureFragmentOnlineTest {
     fun setUp() {
         storage = Firebase.storage
         storage.useEmulator("10.0.2.2", 9199)
-        emptyFirebaseStorage(storage)
+        runBlocking { emptyFirebaseStorage(storage.reference) }
         emptyLocalFiles(picturesDir)
 
         // Open the drawer

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentTestHelper.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentTestHelper.kt
@@ -1,11 +1,9 @@
 package com.github.factotum_sdp.factotum.ui.picture
 
 import androidx.test.espresso.Espresso.onView
-import androidx.test.espresso.action.ViewActions
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.swipeLeft
 import androidx.test.espresso.contrib.DrawerActions.open
-import androidx.test.espresso.matcher.ViewMatchers
 import androidx.test.espresso.matcher.ViewMatchers.withId
 import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiDevice

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentTestHelper.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentTestHelper.kt
@@ -1,6 +1,16 @@
 package com.github.factotum_sdp.factotum.ui.picture
 
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.action.ViewActions.click
+import androidx.test.espresso.action.ViewActions.swipeLeft
+import androidx.test.espresso.contrib.DrawerActions.open
+import androidx.test.espresso.matcher.ViewMatchers
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.uiautomator.UiDevice
+import com.github.factotum_sdp.factotum.R
+import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.google.firebase.storage.StorageReference
 import kotlinx.coroutines.tasks.await
 import java.io.File
@@ -48,4 +58,21 @@ fun triggerCancel(device: UiDevice) {
     device.executeShellCommand("input keyevent 61")
     device.executeShellCommand("input keyevent 61")
     device.executeShellCommand("input keyevent 62")
+}
+
+fun goToPictureFragment() {
+    // Open the drawer
+    onView(withId(R.id.drawer_layout))
+        .perform(open())
+    onView(withId(R.id.roadBookFragment))
+        .perform(click())
+
+    // Click on one of the roadbook
+    val destID = DestinationRecords.RECORDS[2].destID
+    onView(withText(destID)).perform(click())
+
+    // Go to the picture fragment
+    onView(withId(R.id.viewPager)).perform(swipeLeft())
+    onView(withId(R.id.viewPager)).perform(swipeLeft())
+    onView(withId(R.id.viewPager)).perform(swipeLeft())
 }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentTestHelper.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/PictureFragmentTestHelper.kt
@@ -1,6 +1,6 @@
 package com.github.factotum_sdp.factotum.ui.picture
 
-import com.google.firebase.storage.FirebaseStorage
+import androidx.test.uiautomator.UiDevice
 import com.google.firebase.storage.StorageReference
 import kotlinx.coroutines.tasks.await
 import java.io.File
@@ -31,4 +31,21 @@ fun emptyLocalFiles(dir: File) {
         }
         file.delete()
     }
+}
+
+fun triggerShutter(device : UiDevice) {
+    device.executeShellCommand("input keyevent 27")
+}
+
+fun triggerDone(device: UiDevice) {
+    device.executeShellCommand("input keyevent 61")
+    device.executeShellCommand("input keyevent 61")
+    device.executeShellCommand("input keyevent 62")
+}
+
+fun triggerCancel(device: UiDevice) {
+    device.executeShellCommand("input keyevent 61")
+    device.executeShellCommand("input keyevent 61")
+    device.executeShellCommand("input keyevent 61")
+    device.executeShellCommand("input keyevent 62")
 }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/SharedPictureFragmentValue.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/SharedPictureFragmentValue.kt
@@ -5,7 +5,7 @@ import com.google.firebase.storage.StorageReference
 import kotlinx.coroutines.tasks.await
 import java.io.File
 
-const val TIME_WAIT_SHUTTER = 3000L
+const val TIME_WAIT_SHUTTER = 5000L
 const val TIME_WAIT_DONE_OR_CANCEL = 3000L
 const val TIME_WAIT_UPLOAD = 500L
 

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/SharedPictureFragmentValue.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/SharedPictureFragmentValue.kt
@@ -19,6 +19,9 @@ fun emptyFirebaseStorage(storage: FirebaseStorage) {
 
 fun emptyLocalFiles(dir: File) {
     dir.listFiles()?.forEach { file ->
+        if (file.isDirectory) {
+            emptyLocalFiles(file) // Recursively delete files in the directory
+        }
         file.delete()
     }
 }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/SharedPictureFragmentValue.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/SharedPictureFragmentValue.kt
@@ -1,6 +1,8 @@
 package com.github.factotum_sdp.factotum.ui.picture
 
 import com.google.firebase.storage.FirebaseStorage
+import com.google.firebase.storage.StorageReference
+import kotlinx.coroutines.tasks.await
 import java.io.File
 
 const val TIME_WAIT_SHUTTER = 5000L
@@ -9,13 +11,18 @@ const val TIME_WAIT_UPLOAD = 500L
 
 
 // HELPER METHODS
-fun emptyFirebaseStorage(storage: FirebaseStorage) {
-    storage.reference.listAll().addOnSuccessListener { listResult ->
-        listResult.items.forEach { item ->
-            item.delete()
-        }
+suspend fun emptyFirebaseStorage(storageRef: StorageReference) {
+    val listResult = storageRef.listAll().await()
+
+    listResult.items.forEach { item ->
+        item.delete().await()
+    }
+
+    listResult.prefixes.forEach { prefix ->
+        emptyFirebaseStorage(prefix)
     }
 }
+
 
 fun emptyLocalFiles(dir: File) {
     dir.listFiles()?.forEach { file ->

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/SharedPictureFragmentValue.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/picture/SharedPictureFragmentValue.kt
@@ -5,7 +5,7 @@ import com.google.firebase.storage.StorageReference
 import kotlinx.coroutines.tasks.await
 import java.io.File
 
-const val TIME_WAIT_SHUTTER = 5000L
+const val TIME_WAIT_SHUTTER = 3000L
 const val TIME_WAIT_DONE_OR_CANCEL = 3000L
 const val TIME_WAIT_UPLOAD = 500L
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/MainActivity.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/MainActivity.kt
@@ -2,7 +2,6 @@ package com.github.factotum_sdp.factotum
 
 import android.os.Bundle
 import android.widget.TextView
-import androidx.activity.OnBackPressedCallback
 import androidx.appcompat.app.AppCompatActivity
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.ViewModelProvider
@@ -17,7 +16,6 @@ import androidx.navigation.ui.setupActionBarWithNavController
 import androidx.navigation.ui.setupWithNavController
 import com.github.factotum_sdp.factotum.data.Role
 import com.github.factotum_sdp.factotum.databinding.ActivityMainBinding
-import com.github.factotum_sdp.factotum.placeholder.UsersPlaceHolder
 import com.google.android.material.navigation.NavigationView
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.ktx.auth

--- a/app/src/main/java/com/github/factotum_sdp/factotum/MainActivity.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/MainActivity.kt
@@ -49,8 +49,8 @@ class MainActivity : AppCompatActivity() {
         // In order to keep out the NavigateUpButton which would mask the HamburgerButton
         appBarConfiguration = AppBarConfiguration(
             setOf(
-                R.id.roadBookFragment, R.id.pictureFragment,
-                R.id.directoryFragment, R.id.loginFragment, R.id.routeFragment,
+                R.id.roadBookFragment, R.id.directoryFragment,
+                R.id.loginFragment, R.id.routeFragment,
                 R.id.displayFragment
             ), drawerLayout
         )
@@ -115,7 +115,6 @@ class MainActivity : AppCompatActivity() {
         when (role) {
             Role.CLIENT -> {
                 navMenu.findItem(R.id.roadBookFragment).isVisible = false
-                navMenu.findItem(R.id.pictureFragment).isVisible = false
                 navMenu.findItem(R.id.directoryFragment).isVisible = false
                 navMenu.findItem(R.id.routeFragment).isVisible = false
                 navMenu.findItem(R.id.displayFragment).isVisible = true
@@ -123,7 +122,6 @@ class MainActivity : AppCompatActivity() {
 
             else -> {
                 navMenu.findItem(R.id.roadBookFragment).isVisible = true
-                navMenu.findItem(R.id.pictureFragment).isVisible = true
                 navMenu.findItem(R.id.directoryFragment).isVisible = true
                 navMenu.findItem(R.id.routeFragment).isVisible = true
                 navMenu.findItem(R.id.displayFragment).isVisible = true

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordDetailsFragment.kt
@@ -40,7 +40,7 @@ class DRecordDetailsFragment: Fragment() {
         adapter.addFragment(DRecordInfoFragment(rec))
         adapter.addFragment(RouteFragment())
         adapter.addFragment(DirectoryFragment()) // To be replaced with ContactDetailsFragment()
-        adapter.addFragment(PictureFragment())
+        adapter.addFragment(PictureFragment(rec.clientID))
         viewPager.adapter = adapter
 
         return view

--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -13,10 +13,6 @@
             android:icon="@android:drawable/ic_menu_call"
             android:title="@string/menu_directory" />
         <item
-            android:id="@+id/pictureFragment"
-            android:icon="@drawable/ic_menu_camera"
-            android:title="@string/menu_picture" />
-        <item
             android:id="@+id/routeFragment"
             android:icon="@android:drawable/ic_dialog_map"
             android:title="@string/menu_maps" />

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -40,10 +40,6 @@
         android:label="Record details"
         tools:layout="@layout/fragment_drecord_details"/>
     <fragment
-        android:id="@+id/pictureFragment"
-        android:name="com.github.factotum_sdp.factotum.ui.picture.PictureFragment"
-        android:label="Picture"/>
-    <fragment
         android:id="@+id/directoryFragment"
         android:name="com.github.factotum_sdp.factotum.ui.directory.DirectoryFragment"
         android:label="Directory"

--- a/database-debug.log
+++ b/database-debug.log
@@ -1,2 +1,2 @@
-17:00:02.243 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
-17:00:02.360 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
+18:35:25.897 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+18:35:26.031 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000

--- a/database-debug.log
+++ b/database-debug.log
@@ -1,2 +1,2 @@
-22:22:57.946 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
-22:22:58.030 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
+17:00:02.243 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+17:00:02.360 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000

--- a/database-debug.log
+++ b/database-debug.log
@@ -1,2 +1,2 @@
-18:35:25.897 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
-18:35:26.031 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000
+05:22:20.037 [NamespaceSystem-akka.actor.default-dispatcher-5] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
+05:22:20.186 [main] INFO com.firebase.server.forge.App$ - Listening at 127.0.0.1:9000

--- a/firestore-debug.log
+++ b/firestore-debug.log
@@ -1,4 +1,4 @@
-Apr 19, 2023 6:35:24 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Apr 20, 2023 5:22:18 AM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8080
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:
@@ -7,19 +7,3 @@ If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment
 
 Dev App Server is now running.
 
-Apr 19, 2023 7:24:45 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Apr 19, 2023 7:26:08 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
-INFO: Websocket client disconnected
-Apr 19, 2023 7:26:09 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Apr 19, 2023 7:31:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
-INFO: Websocket client disconnected
-Apr 19, 2023 7:31:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Apr 19, 2023 8:03:30 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
-INFO: Websocket client disconnected
-Apr 19, 2023 8:03:30 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
-INFO: Connected to new websocket client
-Apr 19, 2023 8:03:31 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
-INFO: Websocket client disconnected

--- a/firestore-debug.log
+++ b/firestore-debug.log
@@ -1,4 +1,4 @@
-Apr 18, 2023 10:22:56 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Apr 19, 2023 5:00:00 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8080
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:

--- a/firestore-debug.log
+++ b/firestore-debug.log
@@ -7,3 +7,13 @@ If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment
 
 Dev App Server is now running.
 
+Apr 19, 2023 7:24:45 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Apr 19, 2023 7:26:08 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+INFO: Websocket client disconnected
+Apr 19, 2023 7:26:09 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Apr 19, 2023 7:31:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+INFO: Websocket client disconnected
+Apr 19, 2023 7:31:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client

--- a/firestore-debug.log
+++ b/firestore-debug.log
@@ -17,3 +17,9 @@ Apr 19, 2023 7:31:14 PM com.google.cloud.datastore.emulator.firestore.websocket.
 INFO: Websocket client disconnected
 Apr 19, 2023 7:31:14 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
 INFO: Connected to new websocket client
+Apr 19, 2023 8:03:30 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+INFO: Websocket client disconnected
+Apr 19, 2023 8:03:30 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler initChannel
+INFO: Connected to new websocket client
+Apr 19, 2023 8:03:31 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketChannelHandler channelClosed
+INFO: Websocket client disconnected

--- a/firestore-debug.log
+++ b/firestore-debug.log
@@ -1,4 +1,4 @@
-Apr 19, 2023 5:00:00 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
+Apr 19, 2023 6:35:24 PM com.google.cloud.datastore.emulator.firestore.websocket.WebSocketServer start
 INFO: Started WebSocket server on ws://127.0.0.1:9150
 API endpoint: http://127.0.0.1:8080
 If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:


### PR DESCRIPTION
Implement the link between the `PictureFragment` and the `DestinationRecord`. So the `PictureFragment` is not anymore accessible with the drawer menu, now it is only inside the `DestinationRecord` when tapping on one of them, you can swap an access it here like previously done, but no it is correctly linked to it so when taking a photo, it will store it locally and inside the Firebase Storage into a file with the name of the client linked to the DestinationRecord.

The feature did not took so much time to implement, but caused a lot of issues in the test with UiSelector mainly but also now have to check what is inside the folder instead of just checking all the files inside the storage. So a lot of rework here and it should be more stable than before!