### PR TITLE
Implement/listen to live location

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/MainActivityTest.kt
@@ -162,7 +162,7 @@ class MainActivityTest {
         GeneralUtils.fillUserEntryAndEnterTheApp("boss@gmail.com", "123456")
 
         onView(withId(R.id.drawer_layout)).perform(DrawerActions.open())
-        onView(withText("boss@gmail.com")).check(matches(isDisplayed()))
+        //onView(withText("boss@gmail.com")).check(matches(isDisplayed()))
         onView(withText("Boss (BOSS)")).check(matches(isDisplayed()))
     }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/MainActivity.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/MainActivity.kt
@@ -5,7 +5,6 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.navigation.NavOptions
 import androidx.navigation.findNavController
 import androidx.navigation.fragment.NavHostFragment
@@ -90,7 +89,6 @@ class MainActivity : AppCompatActivity() {
         listenLogoutButton()
     }
 
-
     fun applicationSettingsViewModel(): SettingsViewModel {
         return settings
     }
@@ -113,18 +111,22 @@ class MainActivity : AppCompatActivity() {
 
         // Instantiate the current user
         user = ViewModelProvider(this)[UserViewModel::class.java]
-        binding.navView.findViewTreeLifecycleOwner()?.let { lco ->
-            user.loggedInUser.observe(lco) {
-                val format = "${it.name} (${it.role})"
-                userName.text = format
-                email.text = it.email
 
-                // Update the menu items and navigate to the predefined fragment
-                // according to the user role
-                updateMenuItems(it.role)
-                navigateToFragment(it.role)
-                scheduleUpload(it.role)
-            }
+        user.loggedInUser.observe(this) {
+            val format = "${it.name} (${it.role})"
+            userName.text = format
+            //email.text = it.email // Commented temporarily to show user live location
+
+            // Update the menu items and navigate to the predefined fragment
+            // according to the user role
+            updateMenuItems(it.role)
+            navigateToFragment(it.role)
+            scheduleUpload(it.role)
+        }
+        user.userLocation.observe(this) {
+            val coordinatesFormat =
+                "[${it?.latitude} ; ${it?.longitude}]"
+            email.text = coordinatesFormat
         }
     }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/UserViewModel.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/UserViewModel.kt
@@ -3,7 +3,9 @@ package com.github.factotum_sdp.factotum
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
 import com.github.factotum_sdp.factotum.models.User
+import com.github.factotum_sdp.factotum.ui.roadbook.LocationTrackingHandler
 
 /**
  * ViewModel class for the App User
@@ -14,6 +16,23 @@ class UserViewModel : ViewModel() {
     private val _loggedInUser: MutableLiveData<User> = MutableLiveData()
     val loggedInUser: LiveData<User> = _loggedInUser
 
+    val locationTrackingHandler = LocationTrackingHandler()
+
+    /**
+     * LiveData<Location?> to observe the current user location
+     */
+    val userLocation = locationTrackingHandler.currentLocation.asLiveData()
+
+    /**
+     * LiveData<Boolean> to observe the location service running state
+     */
+    val userHasTrackingEnabled = locationTrackingHandler.isTrackingEnabled.asLiveData()
+
+    /**
+     * Set the logged in app user
+     *
+     * @param loggedInUser: User
+     */
     fun setLoggedInUser(loggedInUser: User) {
         _loggedInUser.postValue(loggedInUser)
     }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/UserViewModel.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/UserViewModel.kt
@@ -14,9 +14,12 @@ import com.github.factotum_sdp.factotum.ui.roadbook.LocationTrackingHandler
 class UserViewModel : ViewModel() {
 
     private val _loggedInUser: MutableLiveData<User> = MutableLiveData()
-    val loggedInUser: LiveData<User> = _loggedInUser
-
     val locationTrackingHandler = LocationTrackingHandler()
+
+    /**
+     * LiveData<User> to observe the current user logged in
+     */
+    val loggedInUser: LiveData<User> = _loggedInUser
 
     /**
      * LiveData<Location?> to observe the current user location

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/FusedLocationClient.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/FusedLocationClient.kt
@@ -60,6 +60,5 @@ class FusedLocationClient(
             }
         }
     }
-
 }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/models/Contact.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/models/Contact.kt
@@ -1,5 +1,7 @@
 package com.github.factotum_sdp.factotum.models
 
+import android.location.Location
+
 data class Contact(
     val username: String = "",
     val role: String = "",
@@ -8,12 +10,12 @@ data class Contact(
     val profile_pic_id: Int = 0,
     val super_client: String? = null,
     val addressName: String? = null,
-    val latitude: Double? = null,
-    val longitude: Double? = null,
+    override val latitude: Double? = null,
+    override val longitude: Double? = null,
     val phone: String = "",
     val details: String? = null
-) {
-    fun hasCoordinates(): Boolean {
-        return latitude != null && longitude != null
+) : Localisable<Contact> {
+    override fun withLocation(location: Location): Contact {
+        return this.copy(latitude = location.latitude, longitude = location.longitude)
     }
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/models/Localisable.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/models/Localisable.kt
@@ -1,0 +1,47 @@
+package com.github.factotum_sdp.factotum.models
+
+import android.location.Location
+
+
+private const val LOCATION_PROVIDER_NAME = "factotum"
+
+/**
+ * The Localisable interface allowing to manage the Localisable entity of the app.
+ * For example, an application User or a Contact.
+ *
+ * Link it the latitude and longitude fields to the android.location.Location object.
+ * Note that The T parameter should be the type of the implemented class
+ */
+interface Localisable<out T: Localisable<T>> {
+
+    val latitude: Double?
+    val longitude: Double?
+
+    /**
+     * Whether the Localisable entity has currently some coordinates
+     * @return Boolean
+     */
+    fun hasCoordinates(): Boolean {
+        return latitude != null && longitude != null
+    }
+
+    /**
+     * Create a new instance from an android.location.Location object
+     * @param location: Location
+     * @return T: the type of the "Localisable" class
+     */
+    fun withLocation(location: Location): T
+
+    /**
+     * Get the current Location of the Localisable entity
+     * Or null if currently no Location is available
+     *
+     * @return Location?
+     */
+    fun getLocation(): Location? {
+        val location = Location(LOCATION_PROVIDER_NAME)
+        location.latitude = latitude ?: return null
+        location.longitude = longitude ?: return null
+        return location
+    }
+}

--- a/app/src/main/java/com/github/factotum_sdp/factotum/models/User.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/models/User.kt
@@ -1,10 +1,18 @@
 package com.github.factotum_sdp.factotum.models
 
+import android.location.Location
+
 /**
  * Data class that captures user information for logged in users retrieved from LoginRepository
  */
 data class User(
     val name: String,
     val email: String,
-    val role: Role
-)
+    val role: Role,
+    override val latitude: Double? = null,
+    override val longitude: Double? = null
+) : Localisable<User> {
+    override fun withLocation(location: Location): User {
+        return this.copy(latitude = location.latitude, longitude = location.longitude)
+    }
+}

--- a/app/src/main/java/com/github/factotum_sdp/factotum/services/LocationService.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/services/LocationService.kt
@@ -20,10 +20,14 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 private const val CHANNEL_ID = "factotum_location_service"
 private const val CHANNEL_NAME = "Factotum Live Location Service"
@@ -69,7 +73,7 @@ class LocationService : Service() {
     }
 
     /**
-     * Set an event for each Location update
+     * Set the event for each Location update
      *
      * @param onLocationUpdate: (Location) -> Unit
      */

--- a/app/src/main/java/com/github/factotum_sdp/factotum/services/LocationService.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/services/LocationService.kt
@@ -30,6 +30,15 @@ private const val CHANNEL_NAME = "Factotum Live Location Service"
 private const val SERVICE_ID = 101
 private const val UPDATE_INTERVAL = 1000L
 
+/**
+ * The LocationService class
+ *
+ * It extends the android.app.Service abstract class,
+ * in order to provide our own Factotum Location service.
+ *
+ * A service is needed to keep a high location update rate whenever
+ * the app is in the background.
+ */
 class LocationService : Service() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -59,22 +68,32 @@ class LocationService : Service() {
         return super.onStartCommand(intent, flags, startId)
     }
 
+    /**
+     * Set an event for each Location update
+     *
+     * @param onLocationUpdate: (Location) -> Unit
+     */
     fun setEventOnLocationUpdate(onLocationUpdate: ((location: Location) -> Unit)) {
         onLocationUpdateEvent = onLocationUpdate
     }
 
     private fun start() {
         startForegroundJob(UPDATE_INTERVAL) { service, notification ->
-            val updatedNotification = notification.setContentText(
-                getString(R.string.loc_service_notification_message)
-            ).setChannelId(CHANNEL_ID)
+            val updatedNotification =
+                notification
+                    .setContentText(getString(R.string.loc_service_notification_message))
+                    .setChannelId(CHANNEL_ID)
             service.notify(SERVICE_ID, updatedNotification.build())
         }
     }
 
+    private fun stop() {
+        stopSelf()
+    }
+
     private fun startForegroundJob(
         interval: Long,
-        onLocationChanges: (
+        onFirstLocationChange: ( // Only called the very first time the service is launched
             service: NotificationManager,
             notification: NotificationCompat.Builder
         ) -> Unit
@@ -89,17 +108,19 @@ class LocationService : Service() {
                 ""
             }
 
-        val notification = NotificationCompat.Builder(this, channelId)
-            .setContentTitle(getString(R.string.loc_service_notification_title))
-            .setContentText("Location: null")
-            .setCategory(Notification.CATEGORY_SERVICE)
-            .setSmallIcon(R.drawable.location)
-            .setOngoing(true)
+        val notification =
+            NotificationCompat
+                .Builder(this, channelId)
+                .setContentTitle(getString(R.string.loc_service_notification_title))
+                .setCategory(Notification.CATEGORY_SERVICE)
+                .setSmallIcon(R.drawable.location)
+                .setOngoing(true)
+                .setContentText(getString(R.string.loc_service_notification_message))
 
         locationClient
             .getLocationUpdates(interval)
             .catch { e -> e.printStackTrace() }
-            .onStart { onLocationChanges(service, notification) }
+            .onStart { onFirstLocationChange(service, notification) }
             .onEach { location ->
                 onLocationUpdateEvent?.let { it(location) }
             }
@@ -118,10 +139,6 @@ class LocationService : Service() {
         chan.lockscreenVisibility = Notification.VISIBILITY_PRIVATE
         service.createNotificationChannel(chan)
         return channelId
-    }
-
-    private fun stop() {
-        stopSelf()
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/LocationTrackingHandler.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/LocationTrackingHandler.kt
@@ -8,18 +8,34 @@ import android.location.Location
 import android.os.IBinder
 import androidx.activity.ComponentActivity
 import com.github.factotum_sdp.factotum.services.LocationService
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * The LocationTrackingHandler class
  *
- * Manage a LocationService instance, to provide
- * a simpler API for the UI part
+ * Stateful object to manage a LocationService instance.
+ * It provides a simpler API for the UI part.
+ * Should be mutated from only one place in the code.
  */
 class LocationTrackingHandler {
 
-    private lateinit var locationService: LocationService
+    private var locationService = LocationService()
     private var onLocationUpdate: ((location: Location) -> Unit)? = null
-    private var isTrackingEnabled = false
+
+    private val _isTrackingEnabled = MutableStateFlow(false)
+    private val _currentLocation = MutableStateFlow<Location?>(null)
+
+    /**
+     * The StateFlow<Location?> giving the current location when the tracking is enabled
+     */
+    val currentLocation = _currentLocation.asStateFlow()
+
+    /**
+     * The StateFlow<Boolean> giving whether the locationService is running or not
+     */
+    val isTrackingEnabled = _isTrackingEnabled.asStateFlow()
 
     /**
      * Start the location service
@@ -40,7 +56,7 @@ class LocationTrackingHandler {
      * @param componentActivity: ComponentActivity
      */
     fun stopLocationService(applicationContext: Context, componentActivity: ComponentActivity) {
-        if (isTrackingEnabled) {
+        if (isTrackingEnabled.value) {
             Intent(applicationContext, LocationService::class.java).apply {
                 action = LocationService.ACTION_STOP
                 unbindWrapForCI { componentActivity.unbindService(it) }
@@ -50,20 +66,17 @@ class LocationTrackingHandler {
     }
 
     /**
-     * Whether the location tracking service is enabled or not
-     * @return Boolean
-     */
-    fun isTrackingEnabled(): Boolean {
-        return isTrackingEnabled
-    }
-
-    /**
      * Set the event on each location update
      * @param onLocationUpdate: (Location) -> Unit
      */
     fun setOnLocationUpdate(onLocationUpdate: ((location: Location) -> Unit)) {
-        this.onLocationUpdate = onLocationUpdate
+        val newCB = { location: Location ->
+            _currentLocation.update { _: Location? -> location }
+            onLocationUpdate(location)
+        }
+        this.onLocationUpdate = newCB
     }
+
 
     // Defines callbacks for service binding, passed to bindService().
     private val connection = object : ServiceConnection {
@@ -75,11 +88,11 @@ class LocationTrackingHandler {
             onLocationUpdate?.let { f ->
                 locationService.setEventOnLocationUpdate(f)
             }
-            isTrackingEnabled = true
+            _isTrackingEnabled.update { _ -> true }
         }
 
         override fun onServiceDisconnected(arg0: ComponentName) {
-            isTrackingEnabled = false
+            _isTrackingEnabled.update { _ -> false }
         }
     }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/LocationTrackingHandler.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/LocationTrackingHandler.kt
@@ -9,12 +9,23 @@ import android.os.IBinder
 import androidx.activity.ComponentActivity
 import com.github.factotum_sdp.factotum.services.LocationService
 
+/**
+ * The LocationTrackingHandler class
+ *
+ * Manage a LocationService instance, to provide
+ * a simpler API for the UI part
+ */
 class LocationTrackingHandler {
 
     private lateinit var locationService: LocationService
     private var onLocationUpdate: ((location: Location) -> Unit)? = null
     private var isTrackingEnabled = false
 
+    /**
+     * Start the location service
+     * @param applicationContext: Context
+     * @param componentActivity: ComponentActivity
+     */
     fun startLocationService(applicationContext: Context, componentActivity: ComponentActivity) {
         Intent(applicationContext, LocationService::class.java).apply {
             action = LocationService.ACTION_START
@@ -23,6 +34,11 @@ class LocationTrackingHandler {
         }
     }
 
+    /**
+     * Stop the location service
+     * @param applicationContext: Context
+     * @param componentActivity: ComponentActivity
+     */
     fun stopLocationService(applicationContext: Context, componentActivity: ComponentActivity) {
         if (isTrackingEnabled) {
             Intent(applicationContext, LocationService::class.java).apply {
@@ -33,15 +49,23 @@ class LocationTrackingHandler {
         } // else the service is already disabled
     }
 
+    /**
+     * Whether the location tracking service is enabled or not
+     * @return Boolean
+     */
     fun isTrackingEnabled(): Boolean {
         return isTrackingEnabled
     }
 
+    /**
+     * Set the event on each location update
+     * @param onLocationUpdate: (Location) -> Unit
+     */
     fun setOnLocationUpdate(onLocationUpdate: ((location: Location) -> Unit)) {
         this.onLocationUpdate = onLocationUpdate
     }
 
-    /** Defines callbacks for service binding, passed to bindService().  */
+    // Defines callbacks for service binding, passed to bindService().
     private val connection = object : ServiceConnection {
 
         override fun onServiceConnected(className: ComponentName, service: IBinder) {

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/LocationTrackingHandler.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/LocationTrackingHandler.kt
@@ -21,7 +21,7 @@ import kotlinx.coroutines.flow.update
  */
 class LocationTrackingHandler {
 
-    private var locationService = LocationService()
+    private lateinit var locationService: LocationService
     private var onLocationUpdate: ((location: Location) -> Unit)? = null
 
     private val _isTrackingEnabled = MutableStateFlow(false)
@@ -88,11 +88,11 @@ class LocationTrackingHandler {
             onLocationUpdate?.let { f ->
                 locationService.setEventOnLocationUpdate(f)
             }
-            _isTrackingEnabled.update { _ -> true }
+            _isTrackingEnabled.update { true }
         }
 
         override fun onServiceDisconnected(arg0: ComponentName) {
-            _isTrackingEnabled.update { _ -> false }
+            _isTrackingEnabled.update { false }
         }
     }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -59,6 +59,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
     private val contactsViewModel : ContactsViewModel by activityViewModels()
 
     private lateinit var currentContacts: List<Contact>
+    private lateinit var locationTrackingHandler: LocationTrackingHandler
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -85,6 +86,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
             currentContacts = it
         }
 
+        locationTrackingHandler = userViewModel.locationTrackingHandler
         setLiveLocationEvent()
 
         return view
@@ -98,7 +100,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
 
     @SuppressLint("NotifyDataSetChanged")
     private fun setLiveLocationEvent() {
-        userViewModel.locationTrackingHandler.setOnLocationUpdate { currentLocation ->
+        locationTrackingHandler.setOnLocationUpdate { currentLocation ->
             rbViewModel.nextDestination()?.let {
                 val destination = clientLocation(it.clientID)
                 destination?.let { dest ->
@@ -237,13 +239,13 @@ class RoadBookFragment : Fragment(), MenuProvider {
         val locationSwitch =
             locationMenu.actionView!!.findViewById<SwitchCompat>(R.id.menu_item_switch)
         locationSwitch?.let {// Load current state to set the switch item
-            it.isChecked = userViewModel.locationTrackingHandler.isTrackingEnabled.value
+            it.isChecked = locationTrackingHandler.isTrackingEnabled.value
         }
         locationSwitch!!.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked)
-                userViewModel.locationTrackingHandler.startLocationService(requireContext(), requireActivity())
+                locationTrackingHandler.startLocationService(requireContext(), requireActivity())
             else if (lifecycle.currentState == Lifecycle.State.RESUMED && this.isVisible) {
-                userViewModel.locationTrackingHandler.stopLocationService(requireContext(), requireActivity())
+                locationTrackingHandler.stopLocationService(requireContext(), requireActivity())
             }
         }
     }
@@ -354,7 +356,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
     }
 
     override fun onDestroy() {
-        userViewModel.locationTrackingHandler.stopLocationService(requireContext(), requireActivity())
+        locationTrackingHandler.stopLocationService(requireContext(), requireActivity())
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -59,7 +59,6 @@ class RoadBookFragment : Fragment(), MenuProvider {
     private val contactsViewModel : ContactsViewModel by activityViewModels()
 
     private lateinit var currentContacts: List<Contact>
-    private lateinit var locationTrackingHandler: LocationTrackingHandler
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
@@ -86,7 +85,6 @@ class RoadBookFragment : Fragment(), MenuProvider {
             currentContacts = it
         }
 
-        locationTrackingHandler = userViewModel.locationTrackingHandler
         setLiveLocationEvent()
 
         return view
@@ -100,7 +98,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
 
     @SuppressLint("NotifyDataSetChanged")
     private fun setLiveLocationEvent() {
-        locationTrackingHandler.setOnLocationUpdate { currentLocation ->
+        userViewModel.locationTrackingHandler.setOnLocationUpdate { currentLocation ->
             rbViewModel.nextDestination()?.let {
                 val destination = clientLocation(it.clientID)
                 destination?.let { dest ->
@@ -239,13 +237,13 @@ class RoadBookFragment : Fragment(), MenuProvider {
         val locationSwitch =
             locationMenu.actionView!!.findViewById<SwitchCompat>(R.id.menu_item_switch)
         locationSwitch?.let {// Load current state to set the switch item
-            it.isChecked = locationTrackingHandler.isTrackingEnabled.value
+            it.isChecked = userViewModel.locationTrackingHandler.isTrackingEnabled.value
         }
         locationSwitch!!.setOnCheckedChangeListener { _, isChecked ->
             if (isChecked)
-                locationTrackingHandler.startLocationService(requireContext(), requireActivity())
+                userViewModel.locationTrackingHandler.startLocationService(requireContext(), requireActivity())
             else if (lifecycle.currentState == Lifecycle.State.RESUMED && this.isVisible) {
-                locationTrackingHandler.stopLocationService(requireContext(), requireActivity())
+                userViewModel.locationTrackingHandler.stopLocationService(requireContext(), requireActivity())
             }
         }
     }
@@ -356,7 +354,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
     }
 
     override fun onDestroy() {
-        locationTrackingHandler.stopLocationService(requireContext(), requireActivity())
+        userViewModel.locationTrackingHandler.stopLocationService(requireContext(), requireActivity())
         super.onDestroy()
     }
 


### PR DESCRIPTION
Prepare some useful tool for @jules552 's task (i.e showing all courier's location on a map)

The main resulting change of that PR is the new observable LiveData fields in the UserViewModel : 
 `userLocation` : to observe the fresh live location of the application user's device.
`userHasTrackingEnabled` : to observe on the activation/deactivation change of the location service.

As an intermediate example, I changed the field mail in the navHeader with the current coordinates.

Other minor things done in that PR :

- Add a `Localisable` Interface, to force the locallisable objects to have coordinates and makes the transition to Android.location.Location object.
- Add two StateFlow read-only attributes to the LocationTrackingHandler.
- Refactor a bit and adjust LocationService, LocationTrackingHandler.
- Move the LocationTrackingHandler from the RoadBookFragment to the UserViewModel for a better scope.