### PR TITLE
Implement ClientID check for the Roadbook updates

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/directory/ContactDetailsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/directory/ContactDetailsFragmentTest.kt
@@ -70,8 +70,6 @@ class ContactDetailsFragmentTest {
             .perform(DrawerActions.open())
         onView(withId(R.id.directoryFragment))
             .perform(click())
-
-        Thread.sleep(4000)
         onView(withText("@" + currContact.username))
             .perform(click())
     }
@@ -172,19 +170,8 @@ class ContactDetailsFragmentTest {
     fun deleteButtonDeletesContact() {
         onView(withId(R.id.button_delete_contact))
             .perform(click())
-        onView(withId(R.id.contacts_recycler_view))
-            .check(matches(isDisplayed()))
-        //check if size of recycler view is 4
-        onView(withId(R.id.contacts_recycler_view))
-            .check(matches(withEffectiveVisibility(Visibility.VISIBLE)))
-            .check { view, noViewFoundException ->
-                if (noViewFoundException != null) {
-                    throw noViewFoundException
-                }
-                val recyclerView = view as RecyclerView
-                val adapter = recyclerView.adapter
-                assert(adapter?.itemCount == 7)
-            }
+
+        onView(withText("@${currContact.username}")).check(doesNotExist())
         resetContact(currContact)
     }
 

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/directory/ContactDetailsFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/directory/ContactDetailsFragmentTest.kt
@@ -70,6 +70,8 @@ class ContactDetailsFragmentTest {
             .perform(DrawerActions.open())
         onView(withId(R.id.directoryFragment))
             .perform(click())
+
+        Thread.sleep(4000)
         onView(withText("@" + currContact.username))
             .perform(click())
     }
@@ -181,7 +183,7 @@ class ContactDetailsFragmentTest {
                 }
                 val recyclerView = view as RecyclerView
                 val adapter = recyclerView.adapter
-                assert(adapter?.itemCount == 4)
+                assert(adapter?.itemCount == 7)
             }
         resetContact(currContact)
     }

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
@@ -36,6 +36,7 @@ import com.github.factotum_sdp.factotum.repositories.ShiftRepository
 import com.github.factotum_sdp.factotum.repositories.ShiftRepository.Companion.DELIVERY_LOG_DB_PATH
 import com.github.factotum_sdp.factotum.roadBookDataStore
 import com.github.factotum_sdp.factotum.shiftDataStore
+import com.github.factotum_sdp.factotum.ui.roadbook.RoadBookFragment.Companion.ROADBOOK_DB_PATH
 import com.github.factotum_sdp.factotum.ui.roadbook.TouchCustomMoves.swipeLeftTheRecordAt
 import com.github.factotum_sdp.factotum.ui.roadbook.TouchCustomMoves.swipeRightTheRecordAt
 import com.github.factotum_sdp.factotum.utils.GeneralUtils
@@ -207,7 +208,7 @@ class RoadBookFragmentTest {
         val db = FirebaseInstance.getDatabase()
         val date = Calendar.getInstance().time
         val ref = db.reference
-            .child("Sheet-shift")
+            .child(ROADBOOK_DB_PATH)
             .child(SimpleDateFormat.getDateInstance(DateFormat.DEFAULT, Locale.ENGLISH).format(date))
 
         // Add 1 record
@@ -323,7 +324,7 @@ class RoadBookFragmentTest {
     @Test
     fun roadBookIsCorrectlyCleared() {
         clearRoadBook()
-        isRecylerViewEmptyCheck()
+        isRecyclerViewEmptyCheck()
     }
 
     @Test
@@ -474,10 +475,19 @@ class RoadBookFragmentTest {
 
     @Test
     fun editARecordDestIDWorks() {
+        val newClientID = DestinationRecords.RECORDS[1].clientID
         swipeRightTheRecordAt(2)
-        onView(withText("X17")).perform(typeText("edited"))
+        onView(withId(R.id.autoCompleteClientID)).perform(clearText()).perform(typeText(newClientID))
         onView(withText(R.string.edit_dialog_update_b)).perform(click())
-        onView((withText("X17edited#1"))).check(matches(isDisplayed()))
+        onView((withText("$newClientID#2"))).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun editWithAWrongClientIDIsShownOnScreen() {
+        swipeRightTheRecordAt(2)
+        onView(withId(R.id.autoCompleteClientID)).perform(typeText("edited"))
+        onView(withId(R.id.editTextRate)).perform(click())
+        onView((withText(R.string.invalid_client_id_text))).check(matches(isDisplayed()))
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -501,13 +511,13 @@ class RoadBookFragmentTest {
     fun editWithAWrongFormatIsAborted() {
         swipeRightTheRecordAt(2)
         onView(withId(R.id.autoCompleteClientID))
-            .perform(click(), typeText("edited"), closeSoftKeyboard())
+            .perform(click(), clearText(), typeText("$newRecordClientID "), closeSoftKeyboard())
         onView(withId(R.id.editTextTimestamp)).perform(click())
         onView(withText(timePickerCancelBLabel)).perform(click())
         onView(withId(R.id.editTextTimestamp)).perform(typeText("2222"))
         onView(withText(R.string.edit_dialog_cancel_b)).perform(click())
 
-        onView((withText("X17edited#1")))
+        onView((withText("$newRecordClientID#1")))
             .check(doesNotExist())
     }
 
@@ -524,7 +534,7 @@ class RoadBookFragmentTest {
         eraseFirstRecTimestamp()
         swipeRightTheRecordAt(2)
         onView(withId(R.id.autoCompleteClientID))
-            .perform(click(), clearText(), typeText("New "), closeSoftKeyboard())
+            .perform(click(), clearText(), typeText("$newRecordClientID "), closeSoftKeyboard())
 
         val cal: Calendar = Calendar.getInstance()
         onView(withId(R.id.editTextTimestamp)).perform(click())
@@ -543,7 +553,7 @@ class RoadBookFragmentTest {
 
         // Edit all fields :
         onView(withId(R.id.autoCompleteClientID))
-            .perform(click(), clearText(), typeText("NewEvery "), closeSoftKeyboard())
+            .perform(click(), clearText(), typeText("$newRecordClientID "), closeSoftKeyboard())
 
         val cal: Calendar = Calendar.getInstance()
         onView(withId(R.id.editTextTimestamp)).perform(click())
@@ -566,7 +576,7 @@ class RoadBookFragmentTest {
         onView(withText(R.string.edit_dialog_update_b)).perform(click())
 
         // Check edited record is corretly displayed :
-        onView(withText("NewEvery#1")).check(matches(isDisplayed()))
+        onView(withText("$newRecordClientID#1")).check(matches(isDisplayed()))
 
         eraseFirstRecTimestamp() // For having no ambiguity btw Timestamp on screen
         onView(withText(startsWith("arrival : ${timestampUntilHourFormat(cal)}"))).check(
@@ -593,10 +603,10 @@ class RoadBookFragmentTest {
     @Test
     fun cancelOnRecordEditionWorks() {
         swipeRightTheRecordAt(2)
-        onView(withText("X17")).perform(typeText("edited"))
+        onView(withId(R.id.autoCompleteClientID)).perform(click(), clearText(), typeText(newRecordClientID))
         onView(withText(R.string.edit_dialog_cancel_b)).perform(click())
         // Same record is displayed, without the edited text happened to his destRecordID
-        onView((withText("X17#1"))).check(matches(isDisplayed()))
+        onView((withText(DestinationRecords.RECORDS[2].destID))).check(matches(isDisplayed()))
     }
 
     // ============================================================================================
@@ -607,8 +617,10 @@ class RoadBookFragmentTest {
     fun dragAndDropByInjectionIsWorking() = runTest {
         // Not possible for the moment in to cover the onMove() of the ItemtTouchHelper Callback,
         // However here, I simulate its behavior to triggers the ViewModel change.
+        val firstDestID = DestinationRecords.RECORDS[2].destID
+        val followingDestID = DestinationRecords.RECORDS[3].destID
         runBlocking {
-            onView(withText("X17#1")).check(isCompletelyAbove(withText("More#1")))
+            onView(withText(firstDestID)).check(isCompletelyAbove(withText(followingDestID)))
             testRule.scenario.onActivity {
                 val fragment = it.supportFragmentManager.fragments.first() as NavHostFragment
 
@@ -625,8 +637,8 @@ class RoadBookFragmentTest {
             delay(WORST_REFRESH_TIME)
         }
 
-        onView(withText("X17#1")).check(matches(isDisplayed()))
-        onView(withText("X17#1")).check(isCompletelyBelow(withText("More#1")))
+        onView(withText(firstDestID)).check(matches(isDisplayed()))
+        onView(withText(firstDestID)).check(isCompletelyBelow(withText(followingDestID)))
     }
 
 
@@ -1048,7 +1060,7 @@ class RoadBookFragmentTest {
 
     }
 
-    private val newRecordClientID = "New"
+    private val newRecordClientID = DestinationRecords.RECORD_TO_ADD.clientID
 
     private fun newRecord() {
         newRecordWithId(newRecordClientID)
@@ -1061,7 +1073,7 @@ class RoadBookFragmentTest {
         onView(withText(R.string.edit_dialog_update_b)).perform(click())
     }
 
-    private fun isRecylerViewEmptyCheck() {
+    private fun isRecyclerViewEmptyCheck() {
         // Find the RecyclerView by its ID
         val recyclerView = onView(withId(R.id.list))
         recyclerView.check(RecyclerViewItemCountAssertion(0))

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
@@ -483,11 +483,20 @@ class RoadBookFragmentTest {
     }
 
     @Test
-    fun editWithAWrongClientIDIsShownOnScreen() {
+    fun editWithAWrongClientIDIsShownOnTheDialog() {
         swipeRightTheRecordAt(2)
         onView(withId(R.id.autoCompleteClientID)).perform(typeText("edited"))
         onView(withId(R.id.editTextRate)).perform(click())
         onView((withText(R.string.invalid_client_id_text))).check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun editWithAWrongClientIDAndConfirmDoesNotApplyChanges() {
+        swipeRightTheRecordAt(2)
+        onView(withId(R.id.autoCompleteClientID))
+            .perform(click(), clearText(), typeText("edited"), closeSoftKeyboard())
+        onView(withText(R.string.edit_dialog_cancel_b)).perform(click())
+        onView(withText(DestinationRecords.RECORDS[2].destID)).check(matches(isDisplayed()))
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/main/java/com/github/factotum_sdp/factotum/placeholder/DestinationRecords.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/placeholder/DestinationRecords.kt
@@ -19,7 +19,13 @@ object DestinationRecords {
         val cal: Calendar = Calendar.getInstance()
         RECORDS.addAll(
             listOf(
-                DestinationRecord("QG#1", "QG", cal.time, 3, 1, arrayListOf(), ""),
+                DestinationRecord(
+                    "QG#1",
+                    "QG",
+                    cal.time,
+                    3,
+                    1,
+                    arrayListOf(), ""),
                 DestinationRecord(
                     "Buhagiat#1",
                     "Buhagiat",
@@ -37,11 +43,19 @@ object DestinationRecords {
                     1,
                     arrayListOf(Action.DELIVER, Action.CONTACT),
                     ""
+                ),
+                DestinationRecord(
+                    "More#1",
+                    "More",
+                    null,
+                    0,
+                    1,
+                    arrayListOf(Action.PICK, Action.DELIVER)
                 )
             )
         )
 
-        for (i in 1..15)
+        for (i in 2..15)
             RECORDS.add(
                 DestinationRecord(
                     "More#$i",

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordEditDialogBuilder.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/DRecordEditDialogBuilder.kt
@@ -23,6 +23,9 @@ import com.google.android.material.snackbar.Snackbar
 import java.text.SimpleDateFormat
 import java.util.Calendar
 
+
+private const val ERASE_B_LABEL = "Erase"
+
 /**
  * That Class represent a DialogBuilder specifically designed to build a custom
  * AlertDialog containing all the fields needed to edit a DestinationRecord.
@@ -75,6 +78,7 @@ class DRecordEditDialogBuilder(
         setClientIDsAdapter()
         setTimestampTimePicker()
         setActionsAdapter()
+        setClientIDFieldCheck()
 
         return super.create()
     }
@@ -91,7 +95,7 @@ class DRecordEditDialogBuilder(
             // On positive button :
             try {
                 rbViewModel.addRecord(
-                    clientIDView.text.toString(),
+                    checkClientID(clientIDView.text.toString()),
                     parseTimestamp(timestampView.text.toString()),
                     parseWaitTimeOrRate(waitingTimeView.text.toString()),
                     parseWaitTimeOrRate(rateView.text.toString()),
@@ -99,7 +103,9 @@ class DRecordEditDialogBuilder(
                     notesView.text.toString()
                 )
                 setSnackBar(host.getString(R.string.snap_text_record_added), 700)
-            } catch (e: java.lang.Exception) {
+            } catch (e: InvalidClientIDException) {
+                setSnackBar(context.getString(R.string.invalid_client_id_snack_bar), 1400)
+            } catch (e: Exception) {
                 setSnackBar(host.getString(R.string.edit_rejected_snap_label), 1400)
             }
         })
@@ -130,7 +136,7 @@ class DRecordEditDialogBuilder(
                 recHasChanged =
                     rbViewModel.editRecordAt(
                         position,
-                        clientIDView.text.toString().trim(),
+                        checkClientID(clientIDView.text.toString()),
                         parseTimestamp(timestampView.text.toString()),
                         parseWaitTimeOrRate(waitingTimeView.text.toString()),
                         parseWaitTimeOrRate(rateView.text.toString()),
@@ -139,13 +145,24 @@ class DRecordEditDialogBuilder(
                     )
                 if (recHasChanged)
                     setSnackBar(context.getString(R.string.edit_confirmed_snap_label), 700)
-            } catch (e: java.lang.Exception) {
+            } catch (e: InvalidClientIDException) {
+                setSnackBar(context.getString(R.string.invalid_client_id_snack_bar), 1400)
+            } catch (e: Exception) {
                 setSnackBar(host.getString(R.string.edit_rejected_snap_label), 1400)
             }
             rbRecyclerView.adapter!!.notifyItemChanged(position)
         })
         return this
     }
+
+    private fun checkClientID(userEntry: String): String {
+        val possibleClientID = userEntry.trim()
+        if(!isValidClientID(possibleClientID))
+            throw InvalidClientIDException()
+        return possibleClientID
+    }
+
+    class InvalidClientIDException: Exception("Invalid Client ID")
 
     private fun setSnackBar(content: String, duration: Int) {
         Snackbar
@@ -176,7 +193,6 @@ class DRecordEditDialogBuilder(
     // Here we will need to get the clients IDs through a ViewModel instance
     // initiated in the mainActivity and representing all the clients
     private fun setClientIDsAdapter() {
-
         clientIDView.threshold = 1
         contactsViewModel.contacts.observe(host.viewLifecycleOwner) { it ->
             val clientIDsAdapter = ArrayAdapter(
@@ -226,7 +242,22 @@ class DRecordEditDialogBuilder(
         actionsView.threshold = 1
     }
 
-    companion object {
-        private const val ERASE_B_LABEL = "Erase"
+    private fun setClientIDFieldCheck() {
+        clientIDView.validator = object : AutoCompleteTextView.Validator {
+            override fun isValid(text: CharSequence): Boolean {
+                val possibleClientID = text.toString().trim()
+                return isValidClientID(possibleClientID)
+            }
+
+            override fun fixText(invalidText: CharSequence): CharSequence {
+                // If .isValid() returns false then the code comes here
+                return context.getString(R.string.invalid_client_id_text)
+            }
+        }
+    }
+
+    private fun isValidClientID(possibleClientID: String): Boolean {
+        val currentContacts = contactsViewModel.contacts.value ?: emptyList()
+        return currentContacts.any { c -> c.username == possibleClientID }
     }
 }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragment.kt
@@ -359,7 +359,7 @@ class RoadBookFragment : Fragment(), MenuProvider {
     }
 
     companion object {
-        private const val ROADBOOK_DB_PATH = "Sheet-shift"
+        const val ROADBOOK_DB_PATH = "Sheet-shift"
         const val DEST_ID_NAV_ARG_KEY = "destID"
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,7 +97,7 @@
     <string name="rb_label_swiper_edition">Swipe R. Editon</string>
     <string name="rb_label_dragdrop"><![CDATA[Drag & Drop]]></string>
     <string name="edit_dialog_cancel_b">Cancel</string>
-    <string name="edit_dialog_update_b">update</string>
+    <string name="edit_dialog_update_b">Confirm</string>
     <string name="menu_view_proof_picture">View Proof Pictures</string>
     <string name="refresh">Refresh</string>
     <string name="hint_dialog_client_id">Client ID</string>
@@ -167,4 +167,6 @@
     <string name="contact_not_found">Contact not found</string>
     <string name="boss_Map">Boss Map</string>
     <string name="decline_end_shift">Not now</string>
+    <string name="invalid_client_id_snack_bar">Invalid Client ID, please correct it</string>
+    <string name="invalid_client_id_text">Invalid Client ID</string>
 </resources>

--- a/firebase_emulator_data/database_export/sdp-firebase-bootcamp-c795d-default-rtdb.json
+++ b/firebase_emulator_data/database_export/sdp-firebase-bootcamp-c795d-default-rtdb.json
@@ -57,7 +57,43 @@
             "profile_pic_id": 2131165334,
             "role": "Courier",
             "surname": "Taylor"
-        }
+        },
+        "More": {
+        "addressName": "",
+        "details": "La loi de Moore",
+        "name": "Moore",
+        "phone": "0796521331",
+        "profile_pic_id": 2131165334,
+        "role": "CLIENT",
+        "surname": "Loi",
+        "username": "More"
+        },
+        "New": {
+        "addressName": "Morges, Switzerland",
+        "details": "",
+        "latitude": 46.5088127,
+        "longitude": 6.496130099999999,
+        "name": "Nouveau",
+        "phone": "0785623569",
+        "profile_pic_id": 2131165334,
+        "role": "CLIENT",
+        "super_client": "",
+        "surname": "Romane",
+        "username": "New"
+        },
+        "QG": {
+        "addressName": "Lausanne, Switzerland",
+        "details": "",
+        "latitude": 46.5196535,
+        "longitude": 6.6322734,
+        "name": "QG",
+        "phone": "07828833488",
+        "profile_pic_id": 2131165334,
+        "role": "CLIENT",
+        "super_client": "",
+        "surname": "QG",
+        "username": "QG"
+        }    
     },
     "profile-dispatch": {
         "9Q9PdkiVQKwgHcuEGyshqXyXHrHT": {


### PR DESCRIPTION
Done in that PR :
- Add a `clientID` check when the app user edit or create a `DestinationRecord`
The edition is validated only if the `clientID` already exists in the directory (`username` field of a `Contact`).
- Clean and adapt the `RoadBookFragmentTest` class
- Add the necessary contacts in the firebase_emulator_data : QG, More, and New.