### PR TITLE
Better injection for a MockLocationClient and his mock journey

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/bossmap/BossMapFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/bossmap/BossMapFragmentTest.kt
@@ -14,6 +14,8 @@ import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.Until
 import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
+import com.github.factotum_sdp.factotum.data.LocationClientFactory
+import com.github.factotum_sdp.factotum.data.MockLocationClient
 import com.github.factotum_sdp.factotum.placeholder.DestinationRecords
 import com.github.factotum_sdp.factotum.placeholder.UsersPlaceHolder
 import com.github.factotum_sdp.factotum.utils.GeneralUtils
@@ -59,6 +61,7 @@ class BossMapFragmentTest {
 
     @Test
     fun testBossMapFragmentWorksProperly(): Unit = runBlocking {
+        LocationClientFactory.setMockClient(MockLocationClient())
         GeneralUtils.fillUserEntryAndEnterTheApp("courier@gmail.com", "123456")
 
         activateLocation()

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
@@ -24,6 +24,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.rule.GrantPermissionRule
 import com.github.factotum_sdp.factotum.MainActivity
 import com.github.factotum_sdp.factotum.R
+import com.github.factotum_sdp.factotum.data.LocationClientFactory
+import com.github.factotum_sdp.factotum.data.MockLocationClient
 import com.github.factotum_sdp.factotum.firebase.FirebaseInstance
 import com.github.factotum_sdp.factotum.firebase.FirebaseStringFormat.firebaseDateFormatted
 import com.github.factotum_sdp.factotum.firebase.FirebaseStringFormat.firebaseSafeString
@@ -966,6 +968,7 @@ class RoadBookFragmentTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun noAutomaticTimestampIsDoneOutOfDestinationPlace() = runTest {
+        injectMockLocationWithDefaultJourney()
 
         // Non timestamped record, hence swipe left shows deletion dialog
         swipeLeftTheRecordAt(1)
@@ -992,6 +995,8 @@ class RoadBookFragmentTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test // Buhagiat is exactly at the same coordinates where the courier will arrive
     fun automaticTimestampIsDoneOnExactDestinationPlace() = runTest {
+        injectMockLocationWithDefaultJourney()
+
         // Non timestamped record, hence swipe left shows deletion dialog
         swipeLeftTheRecordAt(1)
         onView(withText(R.string.delete_dialog_title)).check(matches(isDisplayed()))
@@ -1017,6 +1022,8 @@ class RoadBookFragmentTest {
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
     fun automaticTimestampIsDoneOnDestinationPlacePerimeter() = runTest {
+        injectMockLocationWithDefaultJourney()
+
         // Delete Buhagiat and let the X17 which is at the Rolex center (< 15m of where the courier arrive)
         swipeLeftTheRecordAt(1)
         onView(withText(R.string.delete_dialog_title)).check(matches(isDisplayed()))
@@ -1039,8 +1046,18 @@ class RoadBookFragmentTest {
         }
     }
 
-    // Test with another record on top the timestamp is never done
-
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun fusedLocationEndToEndTest() = runTest {
+        onView(withId(R.id.location_switch)).perform(click())
+        runBlocking {
+            delay(updateTimeMockLocationClient)
+            onView(withId(R.id.drawer_layout))
+                .perform(DrawerActions.open())
+            onView(withText("null")).check(doesNotExist())
+            // Check that the coordinates are not more set to null
+        }
+    }
 
     // ============================================================================================
     // ===================================== Helpers ==============================================
@@ -1049,6 +1066,11 @@ class RoadBookFragmentTest {
     private val timePickerCancelBLabel = "Cancel"
     private val timePickerUpdateBLabel = "OK"
     private val timePickerEraseBLabel = "Erase"
+
+    private fun injectMockLocationWithDefaultJourney() {
+        val mockClient = MockLocationClient()
+        LocationClientFactory.setMockClient(mockClient)
+    }
 
     private fun clickOnShowArchivedButton() {
         openActionBarOverflowOrOptionsMenu(ApplicationProvider.getApplicationContext())
@@ -1132,7 +1154,6 @@ class RoadBookFragmentTest {
         onView(withId(R.id.editTextTimestamp)).perform(click())
         onView(withText(timePickerUpdateBLabel)).perform(click())
         onView(withText(R.string.edit_dialog_update_b)).perform(click())
-
     }
 
     private fun getRbViewModel(): RoadBookViewModel? {

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/utils/GeneralUtils.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/utils/GeneralUtils.kt
@@ -18,8 +18,6 @@ import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
 import com.google.firebase.storage.ktx.storage
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.runBlocking
 
 class GeneralUtils {
     companion object {
@@ -79,7 +77,7 @@ class GeneralUtils {
 
         fun injectLoggedInUser(testRule: ActivityScenarioRule<MainActivity>, loggedInUser: User) {
             testRule.scenario.onActivity {
-                val user = it.applicationUser()
+                val user = it.applicationUserViewModel()
                 user.setLoggedInUser(loggedInUser)
             }
         }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/MainActivity.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/MainActivity.kt
@@ -30,7 +30,6 @@ import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.ktx.database
 import com.google.firebase.ktx.Firebase
 import com.google.firebase.storage.FirebaseStorage
-import com.google.firebase.storage.ktx.storage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -109,7 +108,7 @@ class MainActivity : AppCompatActivity() {
         return settings
     }
 
-    fun applicationUser(): UserViewModel {
+    fun applicationUserViewModel(): UserViewModel {
         return user
     }
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/UserViewModel.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/UserViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import com.github.factotum_sdp.factotum.data.LocationClient
 import com.github.factotum_sdp.factotum.models.User
 import com.github.factotum_sdp.factotum.ui.roadbook.LocationTrackingHandler
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/LocationClientFactory.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/LocationClientFactory.kt
@@ -1,0 +1,39 @@
+package com.github.factotum_sdp.factotum.data
+
+import android.content.Context
+import com.google.android.gms.location.LocationServices
+
+/**
+ * Construct a LocationClient object for the application
+ *
+ */
+object LocationClientFactory {
+
+    private var mockClient: LocationClient? = null
+
+    /**
+     * Provide a LocationClient
+     *
+     * @param applicationContext: Context
+     * @return LocationClient
+     */
+    fun provideLocationClient(applicationContext: Context): LocationClient {
+        mockClient?.let {
+            return it
+        }
+        return FusedLocationClient(
+            applicationContext,
+            LocationServices.getFusedLocationProviderClient(applicationContext)
+        )
+    }
+
+    /**
+     * Set a mock location client,
+     * used in provideLocationClient() instead of the default LocationClient
+     *
+     * @param mockClient: LocationClient
+     */
+    fun setMockClient(mockClient: LocationClient) {
+        this.mockClient = mockClient
+    }
+}

--- a/app/src/main/java/com/github/factotum_sdp/factotum/data/MockLocationClient.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/data/MockLocationClient.kt
@@ -10,26 +10,26 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-private const val TIMES_WITHOUT_MOVING = 2
-class MockLocationClient: LocationClient {
+private val DEFAULT_JOURNEY = listOf(
+    PELICAN,
+    PELICAN,
+    PELICAN_TO_ROLEX_1,
+    PELICAN_TO_ROLEX_2,
+    FRONT_OF_ROLEX
+)
+class MockLocationClient(private val journey: List<Location> = DEFAULT_JOURNEY): LocationClient {
 
     @SuppressLint("MissingPermission")
     override fun getLocationUpdates(interval: Long): Flow<Location> {
         val longerInterval = interval * 4
         return flow {
-            for(i in 0 until TIMES_WITHOUT_MOVING) {
-                emit(PELICAN)
+            for(loc in journey) {
+                emit(loc)
                 delay(longerInterval)
             }
 
-            emit(PELICAN_TO_ROLEX_1)
-            delay(longerInterval)
-
-            emit(PELICAN_TO_ROLEX_2)
-            delay(longerInterval)
-
             while (true) {
-                emit(FRONT_OF_ROLEX)
+                emit(journey.last())
                 delay(longerInterval)
             }
         }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/services/LocationService.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/services/LocationService.kt
@@ -15,19 +15,15 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import com.github.factotum_sdp.factotum.R
 import com.github.factotum_sdp.factotum.data.LocationClient
-import com.github.factotum_sdp.factotum.data.MockLocationClient
+import com.github.factotum_sdp.factotum.data.LocationClientFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 private const val CHANNEL_ID = "factotum_location_service"
 private const val CHANNEL_NAME = "Factotum Live Location Service"
@@ -43,12 +39,12 @@ private const val UPDATE_INTERVAL = 1000L
  * A service is needed to keep a high location update rate whenever
  * the app is in the background.
  */
-class LocationService : Service() {
+class LocationService() : Service() {
 
     private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
     private var onLocationUpdateEvent: ((location: Location) -> Unit)? = null
     private val binder = LocalBinder()
-    private lateinit var locationClient: LocationClient
+    private var locationClient: LocationClient? = null
 
     override fun onBind(p0: Intent?): IBinder? {
         return binder
@@ -56,11 +52,7 @@ class LocationService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        locationClient = MockLocationClient()
-            /*FusedLocationClient(
-            applicationContext,
-            LocationServices.getFusedLocationProviderClient(applicationContext)
-        )*/
+        locationClient = LocationClientFactory.provideLocationClient(applicationContext)
     }
 
     @RequiresApi(Build.VERSION_CODES.Q)
@@ -121,7 +113,7 @@ class LocationService : Service() {
                 .setOngoing(true)
                 .setContentText(getString(R.string.loc_service_notification_message))
 
-        locationClient
+        locationClient!!
             .getLocationUpdates(interval)
             .catch { e -> e.printStackTrace() }
             .onStart { onFirstLocationChange(service, notification) }

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/LocationTrackingHandler.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/roadbook/LocationTrackingHandler.kt
@@ -7,6 +7,7 @@ import android.content.ServiceConnection
 import android.location.Location
 import android.os.IBinder
 import androidx.activity.ComponentActivity
+import com.github.factotum_sdp.factotum.data.LocationClient
 import com.github.factotum_sdp.factotum.services.LocationService
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -26,6 +27,8 @@ class LocationTrackingHandler {
 
     private val _isTrackingEnabled = MutableStateFlow(false)
     private val _currentLocation = MutableStateFlow<Location?>(null)
+
+    private var mockLocationClient: LocationClient? = null
 
     /**
      * The StateFlow<Location?> giving the current location when the tracking is enabled


### PR DESCRIPTION
PR dedicated for using by default the `FusedLocationClient` in the `LocationService`, while still having the possibility to replace it by a `MockLocationClient` during tests.

Moreover now, one can pass directly a List of Location as "journey" in the `MockLocationClient`'s constructor. Hence it is more flexible for testing.

- The `LocationClientFactory` object allows to set a `MockLocationClient` instead of the application's default `LocationClient`.

I read the documentation for the option of a directly using the mock location in the `FusedLocationClient`, but was not so flexible. I finally found that option better. 