### PR TITLE
Magic to make caching and fetching faster

### DIFF
--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/AppDatabase.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/AppDatabase.kt
@@ -9,7 +9,7 @@ import com.github.factotum_sdp.factotum.ui.display.data.courier_boss.CachedFolde
 import com.github.factotum_sdp.factotum.ui.display.data.client.CachedPhoto
 import com.github.factotum_sdp.factotum.ui.display.data.client.CachedPhotoDao
 
-@Database(entities = [CachedFolder::class, CachedPhoto::class], version = 1, exportSchema = false)
+@Database(entities = [CachedFolder::class, CachedPhoto::class], version = 2, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cachedFolderDao(): CachedFolderDao
     abstract fun cachedPhotoDao(): CachedPhotoDao

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/AppDatabase.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/AppDatabase.kt
@@ -9,7 +9,7 @@ import com.github.factotum_sdp.factotum.ui.display.data.courier_boss.CachedFolde
 import com.github.factotum_sdp.factotum.ui.display.data.client.CachedPhoto
 import com.github.factotum_sdp.factotum.ui.display.data.client.CachedPhotoDao
 
-@Database(entities = [CachedFolder::class, CachedPhoto::class], version = 2, exportSchema = false)
+@Database(entities = [CachedFolder::class, CachedPhoto::class], version = 1, exportSchema = false)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun cachedFolderDao(): CachedFolderDao
     abstract fun cachedPhotoDao(): CachedPhotoDao

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/client/CachedPhotoDao.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/client/CachedPhotoDao.kt
@@ -14,6 +14,10 @@ interface CachedPhotoDao {
     @Query("SELECT * FROM cached_photo WHERE folderName = :folderName ORDER BY dateSortKey DESC")
     suspend fun getAllByFolderNameSortedByDate(folderName: String): List<CachedPhoto>
 
+
+    @Query("SELECT * FROM cached_photo WHERE folderName = :folderName AND dateSortKey >= :startOfDay AND dateSortKey < :endOfDay ORDER BY dateSortKey DESC")
+    suspend fun getAllByFolderNameAndDay(folderName: String, startOfDay: Long, endOfDay: Long): List<CachedPhoto>
+
     @Query("SELECT * FROM cached_photo WHERE path = :photoPath LIMIT 1")
     suspend fun getPhotoByPath(photoPath: String): CachedPhoto?
 

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/courier_boss/CachedFolder.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/courier_boss/CachedFolder.kt
@@ -1,9 +1,12 @@
 package com.github.factotum_sdp.factotum.ui.display.data.courier_boss
 
 import androidx.room.Entity
+import androidx.room.Index
 import androidx.room.PrimaryKey
 
-@Entity(tableName = "cached_folders")
+@Entity(tableName = "folder", indices = [Index(value = ["name"])])
 data class CachedFolder(
-    @PrimaryKey val path : String,
+    @PrimaryKey val path: String,
+    val name: String
 )
+

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/courier_boss/CachedFolderDao.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/display/data/courier_boss/CachedFolderDao.kt
@@ -8,8 +8,8 @@ import androidx.room.Query
 
 @Dao
 interface CachedFolderDao {
-    @Query("SELECT * FROM cached_folders")
-    fun getAll(): List<CachedFolder>
+    @Query("SELECT * FROM folder ORDER BY name ASC")
+    suspend fun getAll(): List<CachedFolder>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     fun insertAll(vararg folders: CachedFolder)


### PR DESCRIPTION
Async parallel fetching to Firebase Storage, also the local db is not in order of date for the photo and name for the folder, so sorting is done when inserting new elements and overall should be more responsive. Same for filtering, it's now done by SQL queries, should be way faster. And tons of micro optimizations resulting in an overall better experience.

Last thing that could be done is pagination, but not possible on Firebase Storage, possible on the local db but apparently complicated without Jetpack Compose so unlucky I guess :(