### PR TITLE
Implement BagFragment filter

### DIFF
--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/bag/BagFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/bag/BagFragmentTest.kt
@@ -269,6 +269,52 @@ class BagFragmentTest {
         onView(withText(notes)).check(matches(isDisplayed()))
     }
 
+    @Test
+    fun createAPackAndDeliverItDisplaysTheModifications() {
+        val record = DestinationRecords.RECORD_TO_ADD
+        val clientID = record.clientID
+        val packageName = "Gold bottle"
+        val recipientID = "X17"
+        val notes = "It is the end of SDP"
+
+        createAPackWithNotes(clientID, packageName, recipientID, notes)
+
+        onView(withId(R.id.fab)).perform(click())
+        onView(withId(R.id.autoCompleteClientID))
+            .perform(typeText("$recipientID "))
+
+        onView(withId(R.id.multiAutoCompleteActions))
+            .perform(
+                click(),
+                clearText(),
+                typeText("deliver, contact"),
+                closeSoftKeyboard()
+            )
+
+        onView(withId(R.id.editTextTimestamp)).perform(click())
+        onView(withText(timePickerUpdateBLabel)).perform(click())
+
+        onView(withText(R.string.edit_dialog_update_b)).perform(click())
+
+        onView(withId(R.id.bag_button)).perform(click())
+
+        onView(withText(startsWith(packageName))).check(doesNotExist())
+        onView(withText(containsString(clientID))).check(doesNotExist())
+        onView(withText(containsString(recipientID))).check(doesNotExist())
+        onView(withText(containsString(BagAdapter.DELIVERED_TIMESTAMP_PREFIX))).check(
+            doesNotExist())
+
+        onView(withId(R.id.menu_filter_button)).perform(click())
+
+        onView(withText(startsWith(packageName))).check(matches(isDisplayed()))
+        onView(withText(containsString(clientID))).check(matches(isDisplayed()))
+        onView(withText(containsString(recipientID))).check(matches(isDisplayed()))
+        onView(withText(containsString(BagAdapter.DELIVERED_TIMESTAMP_PREFIX))).check(
+            matches(isDisplayed())
+        )
+
+    }
+
     private fun createAPackWithNotes(clientID: String, packageName: String, recipientID: String, notes: String) {
         onView(withId(R.id.fab)).perform(click())
         onView(withId(R.id.autoCompleteClientID))

--- a/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
+++ b/app/src/androidTest/java/com/github/factotum_sdp/factotum/ui/roadbook/RoadBookFragmentTest.kt
@@ -1134,6 +1134,8 @@ class RoadBookFragmentTest {
 
         onView(withId(R.id.bag_button)).perform(click())
 
+        onView(withId(R.id.menu_filter_button)).perform(click())
+
         onView(withText(startsWith(packageName))).check(matches(isDisplayed()))
         onView(withText(containsString(clientID))).check(matches(isDisplayed()))
         onView(withText(containsString(recipientID))).check(matches(isDisplayed()))
@@ -1159,6 +1161,8 @@ class RoadBookFragmentTest {
 
         onView(withId(R.id.bag_button)).perform(click())
 
+        onView(withId(R.id.menu_filter_button)).perform(click())
+
         onView(withText(startsWith(packageName))).check(matches(isDisplayed()))
         onView(withText(containsString(clientID))).check(matches(isDisplayed()))
         onView(withText(containsString(recipientID))).check(matches(isDisplayed()))
@@ -1181,6 +1185,8 @@ class RoadBookFragmentTest {
 
         onView(withId(R.id.bag_button)).perform(click())
 
+        onView(withId(R.id.menu_filter_button)).perform(click())
+
         onView(withText(startsWith(packageName))).check(matches(isDisplayed()))
         onView(withText(containsString(clientID))).check(matches(isDisplayed()))
         onView(withText(containsString(recipientID))).check(matches(isDisplayed()))
@@ -1194,6 +1200,8 @@ class RoadBookFragmentTest {
         val clientID = DestinationRecords.RECORDS[1].clientID
         val packageName = "Gold bottle"
         val recipientID = "X17"
+
+        addNonDeliveredPackageInBag(1, packageName, recipientID)
 
         swipeRightTheRecordAt(1)
         onView(withId(R.id.editTextTimestamp)).perform(click())
@@ -1250,6 +1258,8 @@ class RoadBookFragmentTest {
         onView(withText(R.string.edit_dialog_update_b)).perform(click())
 
         onView(withId(R.id.bag_button)).perform(click())
+
+        onView(withId(R.id.menu_filter_button)).perform(click())
 
         onView(withText(startsWith(packageName))).check(matches(isDisplayed()))
         onView(withText(containsString(clientID))).check(matches(isDisplayed()))

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/bag/BagFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/bag/BagFragment.kt
@@ -75,8 +75,8 @@ class BagFragment: Fragment(), MenuProvider {
         withSendPackButton.setOnMenuItemClickListener {
             it.isChecked = !it.isChecked
 
-            if(it.isChecked) it.setIcon(R.drawable.blue_send)
-            else it.setIcon(R.drawable.send)
+            if(it.isChecked) it.setIcon(R.drawable.blue_work_history)
+            else it.setIcon(R.drawable.work_history)
 
             bagViewModel.displayDeliveredPacks(it.isChecked)
             true

--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/bag/BagViewModel.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/bag/BagViewModel.kt
@@ -1,9 +1,9 @@
 package com.github.factotum_sdp.factotum.ui.bag
 
-import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.map
 import com.github.factotum_sdp.factotum.models.Bag
 import com.github.factotum_sdp.factotum.models.Pack
 import com.github.factotum_sdp.factotum.repositories.BagRepository
@@ -16,11 +16,19 @@ import java.util.HashMap
  * of the packages delivered or currently delivered
  */
 class BagViewModel(private val repository: BagRepository): ViewModel() {
+
     private val _packages = MutableLiveData<List<Pack>>(listOf())
-    val packages: LiveData<List<Pack>> = _packages
+    val displayedPackages = _packages.map { packs ->
+        if(!withSendPacks) {
+            packs.filter { it.deliveredAt == null }
+        } else {
+            packs
+        }
+    }
 
     private val packageOccurrences = HashMap<Pair<String, String>, Int>()
     private var blockPackUpdate = false
+    private var withSendPacks = false
 
 
     /**
@@ -136,14 +144,34 @@ class BagViewModel(private val repository: BagRepository): ViewModel() {
         }
     }
 
+    /**
+     * Whether the delivered Packs have to be displayed
+     * @param isDisplayed: Boolean
+     */
+    fun displayDeliveredPacks(isDisplayed: Boolean) {
+        withSendPacks = isDisplayed
+        _packages.value = currentPackages()
+    }
+
+    /**
+     * To check the current packs update state
+     * If false, no update of this BagViewModel should be triggered from outside
+     * @return Boolean
+     */
     fun isPackUpdateBlocked(): Boolean {
         return blockPackUpdate
     }
 
+    /**
+     * Set the packs update state to blocked
+     */
     fun blockPackUpdate() {
         blockPackUpdate = true
     }
 
+    /**
+     * Allow the packs update
+     */
     fun allowPackUpdate() {
         blockPackUpdate = false
     }

--- a/app/src/main/res/drawable/blue_history.xml
+++ b/app/src/main/res/drawable/blue_history.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#1FD5D5"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z"/>
+</vector>

--- a/app/src/main/res/drawable/blue_send.xml
+++ b/app/src/main/res/drawable/blue_send.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#1FD5D5" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z"/>
+</vector>

--- a/app/src/main/res/drawable/blue_work_history.xml
+++ b/app/src/main/res/drawable/blue_work_history.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#1FD5D5"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,11c1.49,0 2.87,0.47 4,1.26V8c0,-1.11 -0.89,-2 -2,-2h-4V4c0,-1.11 -0.89,-2 -2,-2h-4C8.89,2 8,2.89 8,4v2H4C2.89,6 2.01,6.89 2.01,8L2,19c0,1.11 0.89,2 2,2h7.68C11.25,20.09 11,19.08 11,18C11,14.13 14.13,11 18,11zM10,4h4v2h-4V4z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M18,13c-2.76,0 -5,2.24 -5,5s2.24,5 5,5s5,-2.24 5,-5S20.76,13 18,13zM19.65,20.35l-2.15,-2.15V15h1v2.79l1.85,1.85L19.65,20.35z"/>
+</vector>

--- a/app/src/main/res/drawable/history.xml
+++ b/app/src/main/res/drawable/history.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M13,3c-4.97,0 -9,4.03 -9,9L1,12l3.89,3.89 0.07,0.14L9,12L6,12c0,-3.87 3.13,-7 7,-7s7,3.13 7,7 -3.13,7 -7,7c-1.93,0 -3.68,-0.79 -4.94,-2.06l-1.42,1.42C8.27,19.99 10.51,21 13,21c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,8v5l4.28,2.54 0.72,-1.21 -3.5,-2.08L13.5,8L12,8z"/>
+</vector>

--- a/app/src/main/res/drawable/work_history.xml
+++ b/app/src/main/res/drawable/work_history.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18,11c1.49,0 2.87,0.47 4,1.26V8c0,-1.11 -0.89,-2 -2,-2h-4V4c0,-1.11 -0.89,-2 -2,-2h-4C8.89,2 8,2.89 8,4v2H4C2.89,6 2.01,6.89 2.01,8L2,19c0,1.11 0.89,2 2,2h7.68C11.25,20.09 11,19.08 11,18C11,14.13 14.13,11 18,11zM10,4h4v2h-4V4z"/>
+    <path android:fillColor="@android:color/white" android:pathData="M18,13c-2.76,0 -5,2.24 -5,5s2.24,5 5,5s5,-2.24 5,-5S20.76,13 18,13zM19.65,20.35l-2.15,-2.15V15h1v2.79l1.85,1.85L19.65,20.35z"/>
+</vector>

--- a/app/src/main/res/menu/bag_menu.xml
+++ b/app/src/main/res/menu/bag_menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <group
+        android:checkableBehavior="all"
+        android:menuCategory="alternative">
+        <item
+            android:id="@+id/menu_filter_button"
+            android:icon="@drawable/send"
+            android:title="@string/with_send_packs_button"
+            app:showAsAction="always" />
+    </group>
+</menu>

--- a/app/src/main/res/menu/bag_menu.xml
+++ b/app/src/main/res/menu/bag_menu.xml
@@ -7,7 +7,7 @@
         android:menuCategory="alternative">
         <item
             android:id="@+id/menu_filter_button"
-            android:icon="@drawable/send"
+            android:icon="@drawable/work_history"
             android:title="@string/with_send_packs_button"
             app:showAsAction="always" />
     </group>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -180,4 +180,5 @@
     <string name="menu_date_picker">date_picker</string>
     <string name="menu_loading_bar">menu_loading_bar</string>
     <string name="notes_presence_indicator">Notes presence indicator</string>
+    <string name="with_send_packs_button">With send packs Button</string>
 </resources>


### PR DESCRIPTION
Implemented a default filter on the BagFragment.

When arriving on the fragment, only the non-delivered packs are displayed, like a real bag !
The delivered packs could still be displayed by just clicking on the top-right "send-arrow" icon.