### PR TITLE
Quick fix to disable conflicts between record details swiping and map swiping.

### DIFF
--- a/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsFragment.kt
+++ b/app/src/main/java/com/github/factotum_sdp/factotum/ui/maps/MapsFragment.kt
@@ -131,11 +131,14 @@ class MapsFragment : Fragment() {
             route?.let {
                 placeMarkers(listOf(it), googleMap)
             }
+            // Remove scroll gestures from the map (to avoid conflicts with the ViewPager)
+            googleMap.uiSettings.isScrollGesturesEnabled = false
         }
         else {
             // places markers on the map and centers the camera
             val destinations = getDestinationsFromRoadbook()
             placeMarkers(destinations, googleMap)
+            googleMap.uiSettings.isScrollGesturesEnabled = true
         }
         // Add zoom controls to the map
         googleMap.uiSettings.isZoomControlsEnabled = true


### PR DESCRIPTION
Just disabled maps scrolling when in the record details.